### PR TITLE
Feature/financial resources support received domestic

### DIFF
--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-actions.js
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-actions.js
@@ -1,0 +1,5 @@
+import { createAction } from 'redux-tools';
+import { FINANCIAL_RESOURCES } from 'router';
+
+export const updateQueryParam = createAction(FINANCIAL_RESOURCES);
+export const updateFiltersSelected = createAction(FINANCIAL_RESOURCES);

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-actions.js
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-actions.js
@@ -1,5 +1,4 @@
 import { createAction } from 'redux-tools';
 import { FINANCIAL_RESOURCES } from 'router';
 
-export const updateQueryParam = createAction(FINANCIAL_RESOURCES);
 export const updateFiltersSelected = createAction(FINANCIAL_RESOURCES);

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-component.jsx
@@ -56,7 +56,7 @@ class Domestic extends PureComponent {
 
 Domestic.propTypes = {
   data: PropTypes.array,
-  selectedValues: PropTypes.array,
+  selectedValues: PropTypes.object,
   onFilterChange: PropTypes.func.isRequired
 };
 

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-component.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { PropTypes } from 'prop-types';
 import BubbleChart from 'components/bubble-chart';
-import MitigationEffectsProvider from 'providers/mitigation-effects-provider';
+import FinancialResourcesProvider from 'providers/financial-resources-provider';
 
 class Domestic extends PureComponent {
   handleNodeClick = (e, id) => {
@@ -26,7 +26,7 @@ class Domestic extends PureComponent {
               />
             )
         }
-        <MitigationEffectsProvider />
+        <FinancialResourcesProvider />
       </div>
     );
   }

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-component.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { PropTypes } from 'prop-types';
 import BubbleChart from 'components/bubble-chart';
 import FinancialResourcesProvider from 'providers/financial-resources-provider';
+import styles from './domestic-styles.scss';
 
 class Domestic extends PureComponent {
   handleNodeClick = (e, id) => {
@@ -11,21 +12,42 @@ class Domestic extends PureComponent {
   };
 
   render() {
-    const { data } = this.props;
+    const { data, selectedValues } = this.props;
     return (
-      <div>
-        {
-          data &&
-            (
-              <BubbleChart
-                width={400}
-                height={400}
-                data={data}
-                handleNodeClick={this.handleNodeClick}
-                tooltipClassName="global_SATooltip"
-              />
-            )
-        }
+      <div className={styles.contentContainer}>
+        <div className={styles.chartContainer}>
+          {
+            data &&
+              (
+                <BubbleChart
+                  width={400}
+                  height={400}
+                  data={data}
+                  handleNodeClick={this.handleNodeClick}
+                  tooltipClassName="global_SATooltip"
+                />
+              )
+          }
+        </div>
+        <div className={styles.infoContainer}>
+          {
+            selectedValues && (
+            <div>
+              <h2 className={styles.label}>
+                {selectedValues.financialFlow.label}
+                {' '}by{' '}
+                {selectedValues.donor && selectedValues.donor.label}
+              </h2>
+              <p className={styles.label}>Principal focus</p>
+              <p className={styles.text}>Principal focus</p>
+              <p className={styles.label}>Support commited</p>
+              <p className={styles.text}>Support commited</p>
+              <p className={styles.label}>Type of funding</p>
+              <p className={styles.text}>Type of funding</p>
+            </div>
+              )
+          }
+        </div>
         <FinancialResourcesProvider />
       </div>
     );
@@ -34,9 +56,10 @@ class Domestic extends PureComponent {
 
 Domestic.propTypes = {
   data: PropTypes.array,
+  selectedValues: PropTypes.array,
   onFilterChange: PropTypes.func.isRequired
 };
 
-Domestic.defaultProps = { data: null };
+Domestic.defaultProps = { data: null, selectedValues: null };
 
 export default Domestic;

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-component.jsx
@@ -1,0 +1,42 @@
+import React, { PureComponent } from 'react';
+import { PropTypes } from 'prop-types';
+import BubbleChart from 'components/bubble-chart';
+import MitigationEffectsProvider from 'providers/mitigation-effects-provider';
+
+class Domestic extends PureComponent {
+  handleNodeClick = (e, id) => {
+    e.preventDefault();
+    const { onFilterChange } = this.props;
+    onFilterChange('domesticId', id);
+  };
+
+  render() {
+    const { data } = this.props;
+    return (
+      <div>
+        {
+          data &&
+            (
+              <BubbleChart
+                width={400}
+                height={400}
+                data={data}
+                handleNodeClick={this.handleNodeClick}
+                tooltipClassName="global_SATooltip"
+              />
+            )
+        }
+        <MitigationEffectsProvider />
+      </div>
+    );
+  }
+}
+
+Domestic.propTypes = {
+  data: PropTypes.array,
+  onFilterChange: PropTypes.func.isRequired
+};
+
+Domestic.defaultProps = { data: null };
+
+export default Domestic;

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-selectors.js
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-selectors.js
@@ -3,8 +3,8 @@ import isEmpty from 'lodash/isEmpty';
 
 const CHART_COLORS = { selected: '#f5b335', default: '#ecf0f1' };
 
-const getData = ({ mitigationEffects = {} }) =>
-  isEmpty(mitigationEffects.data) ? null : mitigationEffects.data;
+const getData = ({ financialResources = {} }) =>
+  isEmpty(financialResources.data) ? null : financialResources.data;
 
 const getDomesticIdParam = ({ location }) =>
   location.query ? location.query.domesticId : null;

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-selectors.js
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-selectors.js
@@ -1,0 +1,29 @@
+import { createStructuredSelector, createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+
+const CHART_COLORS = { selected: '#f5b335', default: '#ecf0f1' };
+
+const getData = ({ mitigationEffects = {} }) =>
+  isEmpty(mitigationEffects.data) ? null : mitigationEffects.data;
+
+const getDomesticIdParam = ({ location }) =>
+  location.query ? location.query.domesticId : null;
+const setBubbleColor = (selectedId, id) =>
+  parseInt(selectedId, 10) === id
+    ? CHART_COLORS.selected
+    : CHART_COLORS.default;
+const getChartData = createSelector([ getData, getDomesticIdParam ], (
+  data,
+  selectedId
+) =>
+  {
+    if (!data) return null;
+    return data.map(e => ({
+      ...e,
+      color: selectedId
+        ? setBubbleColor(selectedId, e.id)
+        : CHART_COLORS.default
+    }));
+  });
+
+export const getDomestic = createStructuredSelector({ data: getChartData });

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-styles.scss
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic-styles.scss
@@ -1,0 +1,43 @@
+@import '~styles/layout.scss';
+
+.contentContainer {
+  @include columns(12);
+
+  @media #{$tablet-portrait} {
+    @include columns(6);
+  }
+
+  margin-top: $gutter-padding;
+  position: relative;
+}
+
+.chartContainer {
+  display: flex;
+  justify-content: center;
+}
+
+.infoContainer {
+  display: flex;
+  align-items: center;
+}
+
+.label {
+  font-family: $font-family-1;
+  font-size: $font-size;
+  color: $theme-color;
+  font-weight: $font-weight-bold;
+}
+
+.text {
+  font-family: $font-family-1;
+  font-size: $font-size;
+  color: $theme-color;
+  margin-bottom: $gutter-padding;
+}
+
+.policy {
+  font-family: $font-family-1;
+  font-size: $font-size-large;
+  color: $theme-color;
+  margin-bottom: $gutter-padding;
+}

--- a/app/javascript/app/pages/financial-resources/support-received/domestic/domestic.js
+++ b/app/javascript/app/pages/financial-resources/support-received/domestic/domestic.js
@@ -1,0 +1,24 @@
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { PropTypes } from 'prop-types';
+import Component from './domestic-component';
+import { getDomestic } from './domestic-selectors';
+
+const mapStateToProps = getDomestic;
+
+class DomesticContainer extends PureComponent {
+  render() {
+    const { handleFilterChange } = this.props;
+    return <Component {...this.props} onFilterChange={handleFilterChange} />;
+  }
+}
+
+DomesticContainer.propTypes = {
+  updateFiltersSelected: PropTypes.func.isRequired,
+  handleFilterChange: PropTypes.func.isRequired,
+  query: PropTypes.object
+};
+
+DomesticContainer.defaultProps = { query: {} };
+
+export default connect(mapStateToProps, null)(DomesticContainer);

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
@@ -5,6 +5,7 @@ import TabSwitcher from 'components/tab-switcher';
 import { Dropdown } from 'cw-components';
 import styles from './support-received-styles.scss';
 import International from './international';
+import Domestic from './domestic';
 
 const INTERNATIONAL_KEY = 'international';
 const DOMESTIC_KEY = 'domestic';
@@ -62,7 +63,7 @@ class SupportReceived extends PureComponent {
   }
 
   render() {
-    const { activeTabValue } = this.props;
+    const { activeTabValue, handleFilterChange } = this.props;
 
     const WithDropdowns = ({ content }) => (
       <Fragment>
@@ -77,7 +78,15 @@ class SupportReceived extends PureComponent {
         value: INTERNATIONAL_KEY,
         component: <WithDropdowns content={<International />} />
       },
-      { name: 'DOMESTIC', value: DOMESTIC_KEY, component: null },
+      {
+        name: 'DOMESTIC',
+        value: DOMESTIC_KEY,
+        component: (
+          <WithDropdowns
+            content={<Domestic handleFilterChange={handleFilterChange} />}
+          />
+        )
+      },
       {
         name: 'NON-MONETIZED',
         value: NON_MONETIZED_KEY,

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
@@ -18,52 +18,26 @@ class SupportReceived extends PureComponent {
   };
 
   renderDropdowns() {
-    const { handleFilterChange, options, values } = this.props;
-
+    const { handleFilterChange, options, values, dropdownConfig } = this.props;
     return (
       <div className={styles.dropdownWrapper}>
-        <Dropdown
-          label="Origin of funds"
-          theme={{ wrapper: styles.dropdown }}
-          options={options.fundOrigin}
-          value={values.fundOrigin}
-          onValueChange={option =>
-            handleFilterChange('fundOrigin', option.value)}
-          hideResetButton
-        />
-        <Dropdown
-          label="Financial flows"
-          theme={{ wrapper: styles.dropdown }}
-          options={options.financialFlow}
-          value={values.financialFlow}
-          onValueChange={option =>
-            handleFilterChange('financialFlows', option.value)}
-          hideResetButton
-        />
-        <Dropdown
-          label="Country"
-          theme={{ wrapper: styles.dropdown }}
-          options={options.country}
-          value={values.country}
-          onValueChange={option =>
-            handleFilterChange('countryValue', option.value)}
-          hideResetButton
-        />
-        <Dropdown
-          label="Chart type"
-          theme={{ wrapper: styles.dropdown }}
-          options={options.chartType}
-          value={values.chartType}
-          onValueChange={option =>
-            handleFilterChange('chartType', option.value)}
-          hideResetButton
-        />
+        {dropdownConfig.map(d => (
+          <Dropdown
+            key={d.label}
+            label={d.label}
+            theme={{ wrapper: styles.dropdown }}
+            options={options[d.slug]}
+            value={values[d.slug]}
+            onValueChange={option => handleFilterChange(d.slug, option.value)}
+            hideResetButton
+          />
+        ))}
       </div>
     );
   }
 
   render() {
-    const { activeTabValue, handleFilterChange } = this.props;
+    const { activeTabValue, handleFilterChange, values } = this.props;
 
     const WithDropdowns = ({ content }) => (
       <Fragment>
@@ -83,7 +57,14 @@ class SupportReceived extends PureComponent {
         value: DOMESTIC_KEY,
         component: (
           <WithDropdowns
-            content={<Domestic handleFilterChange={handleFilterChange} />}
+            content={
+              (
+                <Domestic
+                  selectedValues={values}
+                  handleFilterChange={handleFilterChange}
+                />
+              )
+            }
           />
         )
       },
@@ -117,11 +98,13 @@ SupportReceived.propTypes = {
   updateQueryParam: PropTypes.func.isRequired,
   handleFilterChange: PropTypes.func.isRequired,
   options: PropTypes.object,
-  values: PropTypes.object
+  values: PropTypes.object,
+  dropdownConfig: PropTypes.array
 };
 
 SupportReceived.defaultProps = {
   query: null,
+  dropdownConfig: [],
   section: null,
   activeTabValue: null,
   options: {},

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
@@ -38,34 +38,32 @@ class SupportReceived extends PureComponent {
 
   render() {
     const { activeTabValue, handleFilterChange, values } = this.props;
-
-    const WithDropdowns = ({ content }) => (
+    const WithDropdowns = ({ children }) => (
       <Fragment>
         {this.renderDropdowns()}
-        {content}
+        {children}
       </Fragment>
     );
-
     const renderTabs = [
       {
         name: 'INTERNATIONAL',
         value: INTERNATIONAL_KEY,
-        component: <WithDropdowns content={<International />} />
+        component: (
+          <WithDropdowns>
+            <International />
+          </WithDropdowns>
+        )
       },
       {
         name: 'DOMESTIC',
         value: DOMESTIC_KEY,
         component: (
-          <WithDropdowns
-            content={
-              (
-                <Domestic
-                  selectedValues={values}
-                  handleFilterChange={handleFilterChange}
-                />
-              )
-            }
-          />
+          <WithDropdowns>
+            <Domestic
+              selectedValues={values}
+              handleFilterChange={handleFilterChange}
+            />
+          </WithDropdowns>
         )
       },
       {

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-selectors.js
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-selectors.js
@@ -12,10 +12,15 @@ const getMockedData = () => ({
   fundOrigin: [ 'Bilateral', 'Multilateral' ],
   financialFlow: [ 'Grants', 'Loans', 'All Selected' ],
   country: [ 'All selected' ],
-  chartType: [ 'Flows', 'Comparison' ]
+  chartType: [ 'Flows', 'Comparison' ],
+  donor: [ 'Adaptation Fund' ]
 });
 
 const parseOptions = options => options.map(o => ({ label: o, value: o }));
+const getDonorOptions = createSelector(
+  getMockedData,
+  data => data && data.donor && parseOptions(data.donor) || null
+);
 const getFundOriginOptions = createSelector(
   getMockedData,
   data => data && data.fundOrigin && parseOptions(data.fundOrigin) || null
@@ -33,14 +38,23 @@ const getChartTypeOptions = createSelector(
   data => data && data.chartType && parseOptions(data.chartType) || null
 );
 
-const getfundOriginValues = createSelector(
+const getFundOriginValues = createSelector(
   [ getQueryParams, getFundOriginOptions ],
   (query, options) => {
     if (!query || !query.fundOrigin) return options && options[0];
     return options.find(o => o.value === query.fundOrigin) || null;
   }
 );
-const getfinancialFlowValues = createSelector(
+
+const getDonorValues = createSelector([ getQueryParams, getDonorOptions ], (
+  query,
+  options
+) =>
+  {
+    if (!query || !query.donor) return options && options[0];
+    return options.find(o => o.value === query.donor) || null;
+  });
+const getFinancialFlowValues = createSelector(
   [ getQueryParams, getFinancialFlowOptions ],
   (query, options) => {
     if (!query || !query.financialFlow) return options && options[0];
@@ -55,7 +69,7 @@ const getCountryValues = createSelector([ getQueryParams, getCountryOptions ], (
     if (!query || !query.country) return options && options[0];
     return options.find(o => o.value === query.country) || null;
   });
-const getchartTypeValues = createSelector(
+const getChartTypeValues = createSelector(
   [ getQueryParams, getChartTypeOptions ],
   (query, options) => {
     if (!query || !query.chartType) return options && options[0];
@@ -64,17 +78,33 @@ const getchartTypeValues = createSelector(
 );
 
 const getValues = createStructuredSelector({
-  fundOrigin: getfundOriginValues,
-  financialFlow: getfinancialFlowValues,
+  fundOrigin: getFundOriginValues,
+  financialFlow: getFinancialFlowValues,
   country: getCountryValues,
-  chartType: getchartTypeValues
+  chartType: getChartTypeValues,
+  donor: getDonorValues
 });
 
 const getOptions = createStructuredSelector({
   fundOrigin: getFundOriginOptions,
   financialFlow: getFinancialFlowOptions,
   country: getCountryOptions,
-  chartType: getChartTypeOptions
+  chartType: getChartTypeOptions,
+  donor: getDonorOptions
+});
+
+const getDropdownConfig = createSelector(getQueryParams, query => {
+  const { tab } = query;
+  const dropdownConfig = [
+    { label: 'Origin of funds', slug: 'fundOrigin' },
+    { label: 'Financial flows', slug: 'financialFlow' },
+    { label: 'Chart type', slug: 'chartType' }
+  ];
+  let tabSpecificDropdown = { label: 'Country', slug: 'country' };
+  if (tab === 'domestic') {
+    tabSpecificDropdown = { label: 'Donor', slug: 'donor' };
+  }
+  return dropdownConfig.concat(tabSpecificDropdown);
 });
 
 export const getSupportReceived = createStructuredSelector({
@@ -82,5 +112,6 @@ export const getSupportReceived = createStructuredSelector({
   query: getQueryParams,
   activeTabValue: getActiveTabValue,
   options: getOptions,
-  values: getValues
+  values: getValues,
+  dropdownConfig: getDropdownConfig
 });

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-selectors.js
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-selectors.js
@@ -94,17 +94,18 @@ const getOptions = createStructuredSelector({
 });
 
 const getDropdownConfig = createSelector(getQueryParams, query => {
-  const { tab } = query;
   const dropdownConfig = [
     { label: 'Origin of funds', slug: 'fundOrigin' },
     { label: 'Financial flows', slug: 'financialFlow' },
     { label: 'Chart type', slug: 'chartType' }
   ];
-  let tabSpecificDropdown = { label: 'Country', slug: 'country' };
+  let tabSpecificDropdowns = [ { label: 'Country', slug: 'country' } ];
+  if (!query) return dropdownConfig.concat(tabSpecificDropdowns);
+  const { tab } = query;
   if (tab === 'domestic') {
-    tabSpecificDropdown = { label: 'Donor', slug: 'donor' };
+    tabSpecificDropdowns = [ { label: 'Donor', slug: 'donor' } ];
   }
-  return dropdownConfig.concat(tabSpecificDropdown);
+  return dropdownConfig.concat(tabSpecificDropdowns);
 });
 
 export const getSupportReceived = createStructuredSelector({

--- a/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-component.jsx
@@ -82,35 +82,37 @@ class Summary extends PureComponent {
         </div>
         {
           visTypeSelected.value === 'bubble-chart'
-            ? <div className={styles.contentContainer}>
-              <div className={styles.chartContainer}>
-                <BubbleChart
-                  width={400}
-                  height={400}
-                  data={chartData}
-                  handleNodeClick={this.handleNodeClick}
-                  tooltipClassName="global_SATooltip"
-                />
-              </div>
-              <div className={styles.infoContainer}>
-                {
+            ? (
+              <div className={styles.contentContainer}>
+                <div className={styles.chartContainer}>
+                  <BubbleChart
+                    width={400}
+                    height={400}
+                    data={chartData}
+                    handleNodeClick={this.handleNodeClick}
+                    tooltipClassName="global_SATooltip"
+                  />
+                </div>
+                <div className={styles.infoContainer}>
+                  {
                   summarySelected && (
-                      <div>
-                        <p className={styles.label}>Policy</p>
-                        <h2 className={styles.policy}>
-                          {summarySelected.policy}
-                        </h2>
-                        <p className={styles.label}>Objectives</p>
-                        <p className={styles.text}>
-                          {summarySelected.objectives}
-                        </p>
-                        <p className={styles.label}>Actor</p>
-                        <p className={styles.text}>{summarySelected.actor}</p>
-                      </div>
+                  <div>
+                    <p className={styles.label}>Policy</p>
+                    <h2 className={styles.policy}>
+                      {summarySelected.policy}
+                    </h2>
+                    <p className={styles.label}>Objectives</p>
+                    <p className={styles.text}>
+                      {summarySelected.objectives}
+                    </p>
+                    <p className={styles.label}>Actor</p>
+                    <p className={styles.text}>{summarySelected.actor}</p>
+                  </div>
                     )
                 }
+                </div>
               </div>
-            </div>
+)
             : <div>TABLE</div>
         }
         <ModalMetadata />

--- a/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary.js
+++ b/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary.js
@@ -22,13 +22,7 @@ class SummaryContainer extends PureComponent {
   };
 
   render() {
-    return (
-      <Component
-        {...this.props}
-        onFilterChange={this.onFilterChange}
-        updateDataColor={this.updateDataColor}
-      />
-    );
+    return <Component {...this.props} onFilterChange={this.onFilterChange} />;
   }
 }
 

--- a/app/javascript/app/providers/financial-resources-provider/dummy-data.json
+++ b/app/javascript/app/providers/financial-resources-provider/dummy-data.json
@@ -1,0 +1,98 @@
+[
+  {
+    "theme": "Energy Efficiency",
+    "id": 1,
+    "policy": "National Energy Efficiency Strategy (NEES)",
+    "objectives": "The NEES, approved by Cabinet in 2005, sets energy intensity reduction target for various sectors, as reflected in the 1st BUR.",
+    "type of instrument": "Existing measure",
+    "actor": "Department of Energy",
+    "time horizon": "Current",
+    "value": 319,
+    "unit": "MtCO2e",
+    "GHG": ["CO2"]
+  },
+  {
+    "theme": "Energy Efficiency",
+    "id": 2,
+    "policy": "Integrated Demand Management (IDM) Programme",
+    "objectives": "The IDM covers a range of funding and awareness programmes, which promote energy efficiency and load management.",
+    "type of instrument": "Existing measure",
+    "actor": "Eskom",
+    "time horizon": "Current",
+    "value": 56.8,
+    "unit": "MtCO2e",
+    "GHG": ["CO2"]
+  },
+  {
+    "theme": "Energy Efficiency",
+    "id": 3,
+    "policy": "Municipal Energy Efficiency and Demand Side Management (EEDSM)",
+    "objectives": "The EEDSM programme is a grant fund disbursed to 68 municipalities since 2009, to implement energy efficient retrofits within the municipal infrastruc- ture.",
+    "type of instrument": "Existing measure",
+    "actor": "Department of Energy",
+    "time horizon": "Current",
+    "value": 0.3,
+    "unit": "MtCO2e",
+    "GHG": ["CO2"]
+  },
+  {
+    "theme": "Energy Efficiency",
+    "id": 4,
+    "policy": "Industrial Energy Efficiency Improvement (IEEI) Project",
+    "objectives": "The NCPC develops programmes that reduce pollution and improve resource efficiency in the private sector. The NCPC has identified programmes with a total potential saving of R65 million",
+    "type of instrument": "Existing measure",
+    "actor": "Department of Trade and Industry",
+    "time horizon": "Current",
+    "value": 1.3,
+    "unit": "MtCO2e",
+    "GHG": ["CO2"]
+  },
+  {
+    "theme": "Energy Efficiency",
+    "id": 5,
+    "policy": "SASOL energy efficiency projects",
+    "objectives": "Since 2003 SASOL has implemented a series of energy efficiency programmes, including waste energy utilization, steam compressor upgrades and heat recovery, new energy efficient equipment, and process improvements.",
+    "type of instrument": "Existing measure",
+    "actor": "Sasol",
+    "time horizon": "Current",
+    "value": 5.9,
+    "unit": "MtCO2e",
+    "GHG": ["CO2"]
+  },
+  {
+    "theme": "Electricity generation",
+    "id": 6,
+    "policy": "White Paper Renewable Energy (DME, 2003b)",
+    "objectives": "The Minister of Energy determined that 3,725 MW was required from renewable energy sources during the first phase of the REIPPP programme, to ensure the continued uninterrupted supply of electricity. ",
+    "type of instrument": "Existing measure",
+    "actor": "Department of Energy, National Energy Regulator of South Africa (NERSA), Eskom, Independent Power Producers (IPPs).",
+    "time horizon": "Current",
+    "value": 3.1,
+    "unit": "MtCO2e",
+    "GHG": ["CO2", "CH4", "NO2"]
+  },
+  {
+    "theme": "Electricity generation",
+    "id": 7,
+    "policy": "Eskom Open Cycle Gas Turbines (OCGT)",
+    "objectives": "Between 2007 and 2014 a total of 7,827 net GWh of electricity was generated from Eskom’s OCGT plants",
+    "type of instrument": "Existing measure",
+    "actor": "Eskom",
+    "time horizon": "Current",
+    "value": 0.9,
+    "unit": "MtCO2e",
+    "GHG": ["CO2", "CH4", "NO2"]
+  },
+  {
+    "theme": "Electricity generation",
+    "id": 8,
+    "policy": "Sasol Gas Turbines",
+    "objectives": "SASOL installed 420 MWs of combined cycle gas turbines between 2010 and 2011.",
+    "type of instrument": "Existing measure",
+    "actor": "Sasol",
+    "time horizon": "Current",
+    "value": 6.2,
+    "unit": "MtCO2e",
+    "GHG": ["CO2"]
+  }
+]

--- a/app/javascript/app/providers/financial-resources-provider/financial-resources-provider-actions.js
+++ b/app/javascript/app/providers/financial-resources-provider/financial-resources-provider-actions.js
@@ -1,0 +1,40 @@
+import { createAction, createThunkAction } from 'redux-tools';
+// import { SAAPI } from 'services/api';
+import isEmpty from 'lodash/isEmpty';
+
+import data from './dummy-data.json';
+
+export const fetchFinancialResourcesInit = createAction(
+  'fetchFinancialResourcesInit'
+);
+export const fetchFinancialResourcesReady = createAction(
+  'fetchFinancialResourcesReady'
+);
+export const fetchFinancialResourcesFail = createAction(
+  'fetchFinancialResourcesFail'
+);
+
+export const fetchFinancialResources = createThunkAction(
+  'fetchFinancialResources',
+  () => (dispatch, state) => {
+    const { financialResources } = state();
+    if (isEmpty(financialResources.data) && !financialResources.loading) {
+      dispatch(fetchFinancialResourcesInit());
+      setTimeout(
+        () => {
+          dispatch(fetchFinancialResourcesReady(data));
+        },
+        400
+      );
+      // SAAPI
+      //   .get('mitigation/effects', params)
+      //   .then((data = {}) => {
+      //     dispatch(fetchFinancialResourcesReady(data));
+      //   })
+      //   .catch(error => {
+      //     console.warn(error);
+      //     dispatch(fetchFinancialResourcesFail(error && error.message));
+      //   });
+    }
+  }
+);

--- a/app/javascript/app/providers/financial-resources-provider/financial-resources-provider-reducers.js
+++ b/app/javascript/app/providers/financial-resources-provider/financial-resources-provider-reducers.js
@@ -1,0 +1,22 @@
+import * as actions from './financial-resources-provider-actions';
+
+export const initialState = {
+  loading: false,
+  loaded: false,
+  data: {},
+  error: false
+};
+
+export default {
+  [actions.fetchFinancialResourcesInit]: state => ({ ...state, loading: true }),
+  [actions.fetchFinancialResourcesReady]: (state, { payload }) => ({
+    ...state,
+    loading: false,
+    data: payload
+  }),
+  [actions.fetchFinancialResourcesFail]: (state, { payload }) => ({
+    ...state,
+    loading: false,
+    error: payload
+  })
+};

--- a/app/javascript/app/providers/financial-resources-provider/financial-resources-provider.js
+++ b/app/javascript/app/providers/financial-resources-provider/financial-resources-provider.js
@@ -1,0 +1,29 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import * as actions from './financial-resources-provider-actions';
+import reducers, {
+  initialState
+} from './financial-resources-provider-reducers';
+
+class FinancialResourcesProvider extends PureComponent {
+  componentDidMount() {
+    const { fetchFinancialResources, params } = this.props;
+    fetchFinancialResources(params);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+FinancialResourcesProvider.propTypes = {
+  fetchFinancialResources: PropTypes.func.isRequired,
+  params: PropTypes.object
+};
+
+FinancialResourcesProvider.defaultProps = { params: {} };
+
+export const reduxModule = { actions, reducers, initialState };
+export default connect(null, actions)(FinancialResourcesProvider);

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -9,7 +9,10 @@ import { reduxModule as ghgEmissions } from 'providers/ghg-emissions-provider';
 import { reduxModule as ghgInventory } from 'providers/ghg-inventory-provider';
 import {
   reduxModule as mitigationEffects
-} from 'providers//mitigation-effects-provider';
+} from 'providers/mitigation-effects-provider';
+import {
+  reduxModule as financialResources
+} from 'providers/financial-resources-provider';
 import { reduxModule as worldBank } from 'providers/world-bank-provider';
 import { reduxModule as metadata } from 'providers/metadata-provider';
 import {
@@ -32,6 +35,7 @@ const providersReducers = {
   GHGEmissions: handleModule(ghgEmissions),
   GHGInventory: handleModule(ghgInventory),
   mitigationEffects: handleModule(mitigationEffects),
+  financialResources: handleModule(financialResources),
   WorldBank: handleModule(worldBank),
   metadata: handleModule(metadata),
   countriesOverviewData: handleModule(countriesOverview),


### PR DESCRIPTION
This PR creates the Domestic tab in the Financial resources/support received section:

- Create section with Bubble chart
- Update providers to fetch financial resources mocked data
- Change dropdowns depending on the data. The tabs have different dropdowns in the design

![image](https://user-images.githubusercontent.com/9701591/45149177-3cb77900-b1c9-11e8-9468-13bd15837db7.png)
