### PR TITLE
SA - historical emissions not fetching

### DIFF
--- a/app/javascript/app/providers/ghg-emissions-provider/ghg-emissions-provider-actions.js
+++ b/app/javascript/app/providers/ghg-emissions-provider/ghg-emissions-provider-actions.js
@@ -1,8 +1,6 @@
 import { createAction, createThunkAction } from 'redux-tools';
 import { CWAPI } from 'services/api';
 
-import isEmpty from 'lodash/isEmpty';
-
 export const fetchGHGEmissionsInit = createAction('fetchGHGEmissionsInit');
 export const fetchGHGEmissionsReady = createAction('fetchGHGEmissionsReady');
 export const fetchGHGEmissionsFail = createAction('fetchGHGEmissionsFail');
@@ -11,7 +9,7 @@ export const fetchGHGEmissions = createThunkAction(
   'fetchGHGEmissions',
   params => (dispatch, state) => {
     const { GHGEmissions } = state();
-    if (isEmpty(GHGEmissions.data) && !GHGEmissions.loading) {
+    if (!GHGEmissions.loading) {
       dispatch(fetchGHGEmissionsInit());
       CWAPI
         .get('emissions', params)


### PR DESCRIPTION
This PR fixes the issue of not fetching data in historical emissions on initial render after going through the front page.

The provider was used in several places and has some params that make very difficult to check if the needed data is already fetched or not. As it is not a lot of data I think we can just fetch it again in every page that requires it. 

![image](https://user-images.githubusercontent.com/9701591/45153789-7a220380-b1d5-11e8-86ce-b176fa95d3ee.png)
