### PR TITLE
Fix ruby version in Gemfile, update cw_historical_emissions gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.4.1'
+ruby '2.5.1'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git
-  revision: 80a9046475fb35940161866d46ebeed8f24e5baf
+  revision: 3c7e12464d3263b3ef5a846b50c840cc39f3f9ae
   specs:
     climate_watch_engine (1.0.0)
       aws-sdk (~> 2)
@@ -9,7 +9,7 @@ GIT
       active_model_serializers (~> 0.10.0)
       aws-sdk (~> 2)
       climate_watch_engine (~> 1.0.0)
-      cw_locations (~> 1.0.0)
+      cw_locations (~> 1.0.1)
       pg
       rails (~> 5.1.5)
     cw_locations (1.0.1)
@@ -67,13 +67,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
-    aws-sdk (2.11.108)
-      aws-sdk-resources (= 2.11.108)
-    aws-sdk-core (2.11.108)
+    aws-sdk (2.11.127)
+      aws-sdk-resources (= 2.11.127)
+    aws-sdk-core (2.11.127)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.108)
-      aws-sdk-core (= 2.11.108)
+    aws-sdk-resources (2.11.127)
+      aws-sdk-core (= 2.11.127)
     aws-sigv4 (1.0.3)
     bindex (0.5.0)
     builder (3.2.3)
@@ -119,7 +119,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    pg (1.0.0)
+    pg (1.1.3)
     public_suffix (3.0.2)
     puma (3.12.0)
     rack (2.0.5)
@@ -227,7 +227,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.5.1p57
 
 BUNDLED WITH
    1.16.3


### PR DESCRIPTION
There was a difference between `.ruby-version` file and ruby version in Gemfile. Changed it to be the same everywhere; 2.5.1