### PR TITLE
Move all webpack deps from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,11 @@
     "reselect": "3.0.1",
     "topojson-client": "3.0.0",
     "whatwg-fetch": "^3.0.0",
-    "webpack-cli": "3.1.0"
+    "webpack-cli": "3.1.0",
+    "webpack": "4.16.0",
+    "webpack-dev-server": "3.1.5",
+    "webpack-manifest-plugin": "2.0.3",
+    "webpack-merge": "4.1.0"
   },
   "devDependencies": {
     "babel-core": "6.25.0",
@@ -97,10 +101,6 @@
     "stylelint-config-standard": "16.0.0",
     "stylelint-webpack-plugin": "0.8.0",
     "svg-sprite-loader": "3.9.0",
-    "uglifyjs-webpack-plugin": "1.2.7",
-    "webpack": "4.16.0",
-    "webpack-dev-server": "3.1.5",
-    "webpack-manifest-plugin": "2.0.3",
-    "webpack-merge": "4.1.0"
+    "uglifyjs-webpack-plugin": "1.2.7"
   }
 }


### PR DESCRIPTION
Webpack-cli needs other dependencies to work; move all of them from devDependencies to dependencies as in production mode devDependencies are omitted.