### PR TITLE
Added the Flagship Components importer 

### DIFF
--- a/app/serializers/api/v1/mitigation/flagship_component_serializer.rb
+++ b/app/serializers/api/v1/mitigation/flagship_component_serializer.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: flagship_components
+#
+#  id                    :bigint(8)        not null, primary key
+#  flagship_programme_id :integer
+#  name                  :string           not null
+#  main_activities       :text
+#  lead                  :string
+#  status                :string
+#  milestone             :text
+#  barriers              :text
+#  next_steps            :text
+#  timeframe             :string
+#  support               :text
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
+
+module Api
+  module V1
+    module Mitigation
+      class FlagshipComponentSerializer < ApplicationSerializer
+        attributes :id, :name, :main_activities, :lead, :status,
+                   :milestone, :barriers, :next_steps, :timeframe, :support
+
+        belongs_to :flagship_programme,
+                   serializer: Api::V1::Mitigation::FlagshipProgrammeSerializer
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/mitigation/flagship_programme_serializer.rb
+++ b/app/serializers/api/v1/mitigation/flagship_programme_serializer.rb
@@ -22,6 +22,8 @@ module Api
 
         belongs_to :flagship_theme,
                    serializer: Api::V1::Mitigation::FlagshipThemeSerializer
+        has_many :flagship_components,
+                 serializer: Api::V1::Mitigation::FlagshipComponentSerializer
       end
     end
   end

--- a/app/services/import_mitigation.rb
+++ b/app/services/import_mitigation.rb
@@ -49,6 +49,7 @@ class ImportMitigation
       sub_programs: row[:sub_programs],
       work_package: row[:work_package],
       outcomes: row[:outcomes],
+      description: row[:description],
       position: position
     }
   end

--- a/docs/API.md
+++ b/docs/API.md
@@ -211,12 +211,32 @@ theme | Name | Coordinator | Effects1 ... Effects12 | Created at | Updated at
 {
   data: [
     {
-      description: null,
-      position: 1,
-      flagshipTheme: {
-      name: "The Climate Change Response Public Works Flagship Program",
-      position: 1
-    }
+      "id": 1
+      "description": "South Africa’s location, geography and size all play a role in providing the country with multiple renewable energy (RE)...",
+      "position": 1,
+      "subPrograms": "\"*Renewable Energy Independent Power Producer Procurement (REIPPP) Programme *National Solar Water Heating Programme *Eskom renewable energy projects *Off-grid household electrification *Green industries development *Green Energy Accord *Strategic environmental assessment for Renewable Energy Development Zones \"",
+      "workPackage": "\"*Public Sector RE Programme *Transnet PV Programme (real estate) *Transnet Wayside Energy Storage Programme (freight rail) *Public Sector RE Procurement *NERSA SSEG Registration and Tracking System Development *Integrated RE GCF Proposal and Programme Development *Establishment of Inter- governmental co-ordination mechanism for embedded generation *Embedded RE knowledge products (information web portal/resources) and capacity building *Enhancing grid management and capacity at local government level *Enhancing grid performance through appropriate refurbishment and maintenance of distribution level grids *Embedded RE funding (revenue and tariff modelling, market- based incentives and credit lines) *Distribution-scale renewable energy generation market development *Implementation of Integrated fuel cell technologies, energy storage and renewable energy \"",
+      "outcomes": "Widespread development, integration, use, and affordable access to South Africa’s abundant renewable energy (RE) resources through the large-scale and deployment of appropriate technologies at all scales, driving innovation; localisation of RE goods, services and technologies; energy security and economic growth",
+      "flagshipTheme": {
+        "id": 1,
+        "name": "The Climate Change Response Public Works Flagship Program",
+        "position": 1
+      },
+      "flagshipComponents": [
+        {
+          "id": 33,
+          "name": "Energy Efficiency in Public Buildings Programme",
+          "mainActivities": "\"*Preparation of detailed business case and implementation plan *Municipal engagements *Operationalisation of programme \"",
+          "lead": "DOE,DPW,NBI",
+          "status": "Appraisal is being finalized",
+          "milestone": "\"*Implementation preparation *Operationalisation/ Rollout \"",
+          "barriers": null,
+          "nextSteps": "\"*Finalisation DEA contribution *Finalisation of appraisal *DPW, DEA, DOE DDG trilateral *Formalisation of institutional Arrangements *Establishment of an EE NDC Implementation and Investment Working Group (including municipalities) *Analysis of current available resources *Integration of DPW work with the ECCS and harmonise the implementation approach of both DPW and DOE *Finalization of pre-commissioning implementation plan *Prepare for engagements with this municipalities to guide the spending of the municipalities in current financial year \"",
+          "timeframe": "Dec-17",
+          "support": "GIZ CSP III"
+        },...
+      ]
     }, ...
-{
+  ]
+}
 ```

--- a/spec/controllers/api/v1/mitigation/flagship_programmes_controller_spec.rb
+++ b/spec/controllers/api/v1/mitigation/flagship_programmes_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Mitigation::FlagshipProgrammesController, type: :controller do
   context do
     let!(:some_programmes) {
-      FactoryBot.create_list(:flagship_programme_complete, 3)
+      FactoryBot.create_list(:flagship_programme_complete_with_components, 3)
     }
 
     describe 'GET index' do
@@ -16,6 +16,12 @@ describe Api::V1::Mitigation::FlagshipProgrammesController, type: :controller do
         get :index, format: :json
         parsed_body = JSON.parse(response.body)
         expect(parsed_body[parsed_body.keys.first].length).to eq(3)
+      end
+
+      it 'lists the components' do
+        get :index, format: :json
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['data'].last['flagshipComponents'].length).to eq(2)
       end
     end
   end

--- a/spec/factories/flagship_programmes.rb
+++ b/spec/factories/flagship_programmes.rb
@@ -23,6 +23,19 @@ FactoryBot.define do
 
     factory :flagship_programme_complete, class: 'Mitigation::FlagshipProgramme' do
       association :flagship_theme, factory: :flagship_theme, strategy: :build
+
+      factory :flagship_programme_complete_with_components,
+              class: 'Mitigation::FlagshipProgramme' do
+        transient do
+          components_count { 2 }
+        end
+
+        after(:create) do |programme, evaluator|
+          create_list(:flagship_component,
+                      evaluator.components_count,
+                      flagship_programme: programme)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The flagship components weren't imported.
Added the importer and the `flagship_programmes` endpoint now includes the `flagship_components`.

Also, after importing all the data I came to realize that the there's always only one `flagship_programme` for each `flagship_theme`. Maybe this 2 models should be merged in another PR.