### PR TITLE
Feature/population last available year

### DIFF
--- a/app/javascript/app/components/header/header-component.jsx
+++ b/app/javascript/app/components/header/header-component.jsx
@@ -34,8 +34,10 @@ class Header extends PureComponent {
             </div>
             <div className={cx(styles.navElement, styles.pageTitleContainer)}>
               <Link to="/" onTouchStart={undefined} onMouseDown={undefined}>
-                <div className={styles.climateText}>SOUTH AFRICA BIENNIAL</div>
-                <div className={styles.reportText}>UPDATE REPORT EXPLORER</div>
+                <div className={styles.climateText}>SOUTH AFRICA</div>
+                <div className={styles.reportText}>
+                  BIENNIAL UPDATE REPORT EXPLORER
+                </div>
               </Link>
             </div>
             <div className={cx(styles.navElement, styles.flagContainer)}>

--- a/app/javascript/app/pages/national-circumstances/population/population-selectors.js
+++ b/app/javascript/app/pages/national-circumstances/population/population-selectors.js
@@ -62,7 +62,7 @@ export const getYearSelected = createSelector(
   [ getYearOptions, getYearParam ],
   (years, year) => {
     if (!years) return null;
-    if (!year) return years[0];
+    if (!year) return years[years.length - 1];
     return years.find(y => y.value === year);
   }
 );


### PR DESCRIPTION
Tiny PR changing the population default year to the last one and making some little adjustment in the header. The client required to change all default views to last available year. That's the only one I can find in the site

![image](https://user-images.githubusercontent.com/9701591/47491724-b7a52380-d84b-11e8-929d-76927e6a8d64.png)

![image](https://user-images.githubusercontent.com/9701591/47491697-abb96180-d84b-11e8-9906-a19573a471cd.png)
