### PR TITLE
Change column names in mitigation actions

### DIFF
--- a/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-selectors.js
+++ b/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-selectors.js
@@ -27,7 +27,7 @@ const defaultColumns = [
   'actor',
   'time_horizon',
   'ghg',
-  'estimated_emission_reduction'
+  'estimated_emissions_reduction'
 ];
 
 const ellipsisColumns = [];
@@ -79,7 +79,7 @@ const renameMitigationColumns = createSelector(getParsedMitigation, data => {
           updatedD.time_horizon = d.timeHorizon;
           break;
         case 'estimatedEmissionReduction':
-          updatedD.estimated_emission_reduction = d.estimatedEmissionReduction;
+          updatedD.estimated_emissions_reduction = d.estimatedEmissionReduction;
           break;
         default:
           updatedD[key] = d[key];

--- a/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-selectors.js
+++ b/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-selectors.js
@@ -21,7 +21,7 @@ const getActiveTabValue = createSelector(
 const defaultColumns = [
   'theme',
   'name',
-  'objectives',
+  'objectives/progress',
   'type',
   'status',
   'actor',
@@ -29,6 +29,7 @@ const defaultColumns = [
   'ghg',
   'estimated_emission_reduction'
 ];
+
 const ellipsisColumns = [];
 
 const filterMitigationDataByTab = createSelector(
@@ -70,6 +71,9 @@ const renameMitigationColumns = createSelector(getParsedMitigation, data => {
           break;
         case 'mitigationType':
           updatedD.type = d.mitigationType;
+          break;
+        case 'objectives':
+          updatedD['objectives/progress'] = d.objectives;
           break;
         case 'timeHorizon':
           updatedD.time_horizon = d.timeHorizon;


### PR DESCRIPTION
The columns names in Mitigation Actions table are now: Theme, Name, Objectives**/progress**, Type, Status, Actor, Time horizon, Ghg, Estimated emission**s** reduction

I highlighted the ones that changed