### PR TITLE
Feature/enable ghg emissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem 'jbuilder', '~> 2.5'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'responders'
 
-gem 'aws-sdk', '~> 2'
+#gem 'aws-sdk', '~> 2'
+gem 'aws-sdk-s3', '~> 1'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
@@ -52,9 +53,9 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 git 'https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git' do
-  gem 'climate_watch_engine', '~> 1.2.1'
-  gem 'cw_locations', '~> 1.2.2', require: 'locations'
-  gem 'cw_historical_emissions', '~> 1.2.1', require: 'historical_emissions'
+  gem 'climate_watch_engine', '~> 1.3.0'
+  gem 'cw_locations', '~> 1.3.0', require: 'locations'
+  gem 'cw_historical_emissions', '~> 1.3.0', require: 'historical_emissions'
 end
 
 # for debugging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 GIT
   remote: https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git
-  revision: eda3bd83a25a45128b76f8e4bdbdcdb1de4b9afd
+  revision: 9134f4d42fb01390f3896dce9d8c4820076747cd
   specs:
-    climate_watch_engine (1.2.1)
-      aws-sdk (~> 2)
+    climate_watch_engine (1.3.0)
+      aws-sdk-s3 (~> 1)
       rails (~> 5.2.0)
-    cw_historical_emissions (1.2.1)
+    cw_historical_emissions (1.3.0)
       active_model_serializers (~> 0.10.0)
-      aws-sdk (~> 2)
-      climate_watch_engine (~> 1.2.0)
-      cw_locations (~> 1.2.0)
+      aws-sdk-s3 (~> 1)
+      climate_watch_engine (~> 1.3.0)
+      cw_locations (~> 1.3.0)
       pg
       rails (~> 5.2.0)
-    cw_locations (1.2.2)
+    cw_locations (1.3.0)
       active_model_serializers (~> 0.10.0)
-      aws-sdk (~> 2)
-      climate_watch_engine (~> 1.2.0)
+      aws-sdk-s3 (~> 1)
+      climate_watch_engine (~> 1.3.0)
       pg
       rails (~> 5.2.0)
 
@@ -74,13 +74,20 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
     arel (9.0.0)
-    aws-sdk (2.11.130)
-      aws-sdk-resources (= 2.11.130)
-    aws-sdk-core (2.11.130)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.106.0)
+    aws-sdk-core (3.35.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.130)
-      aws-sdk-core (= 2.11.130)
+    aws-sdk-kms (1.11.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.23.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
     bindex (0.5.0)
     builder (3.2.3)
@@ -113,7 +120,7 @@ GEM
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    i18n (1.1.0)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -128,9 +135,9 @@ GEM
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (0.3.2)
+    marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
     mimemagic (0.3.2)
@@ -139,7 +146,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     nio4r (2.3.1)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     pg (1.1.3)
     public_suffix (3.0.2)
@@ -262,12 +269,12 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   annotate
-  aws-sdk (~> 2)
+  aws-sdk-s3 (~> 1)
   byebug
   capybara (~> 2.13)
-  climate_watch_engine (~> 1.2.1)!
-  cw_historical_emissions (~> 1.2.1)!
-  cw_locations (~> 1.2.2)!
+  climate_watch_engine (~> 1.3.0)!
+  cw_historical_emissions (~> 1.3.0)!
+  cw_locations (~> 1.3.0)!
   dotenv-rails
   factory_bot_rails
   jbuilder (~> 2.5)

--- a/app/decorators/controllers/historical_emissions/historical_emissions_controller_decorator.rb
+++ b/app/decorators/controllers/historical_emissions/historical_emissions_controller_decorator.rb
@@ -1,0 +1,28 @@
+HistoricalEmissions::HistoricalEmissionsController.class_eval do
+  HistoricalEmissionsMetadata = Struct.new(
+    :data_sources,
+    :sectors,
+    :gases,
+    :gwps,
+    :locations
+  ) do
+    alias_method :read_attribute_for_serialization, :send
+
+    def self.model_name
+      'metadata'
+    end
+  end
+
+  def meta
+    render(
+      json: HistoricalEmissionsMetadata.new(
+        merged_records(grouped_records),
+        ::HistoricalEmissions::Sector.all,
+        ::HistoricalEmissions::Gas.all,
+        ::HistoricalEmissions::Gwp.all,
+        Location.all
+      ),
+      serializer: ::HistoricalEmissions::MetadataSerializer
+    )
+  end
+end

--- a/app/decorators/services/historical_emissions/import_historical_emissions_decorator.rb
+++ b/app/decorators/services/historical_emissions/import_historical_emissions_decorator.rb
@@ -1,0 +1,18 @@
+HistoricalEmissions::ImportHistoricalEmissions.class_eval do
+  def call
+    cleanup
+    import_sectors(S3CSVReader.read(HistoricalEmissions.meta_sectors_filepath))
+    import_records(S3CSVReader.read(HistoricalEmissions.data_cait_filepath))
+  end
+
+  def record_attributes(row)
+    {
+      location: Location.find_by(iso_code3: row[:iso_code3]),
+      data_source: HistoricalEmissions::DataSource.find_by(name: row[:source]),
+      sector: HistoricalEmissions::Sector.find_by(name: row[:sector]),
+      gas: HistoricalEmissions::Gas.find_or_create_by(name: row[:gas]),
+      gwp: HistoricalEmissions::Gwp.find_or_create_by(name: 'AR2'),
+      emissions: emissions(row)
+    }
+  end
+end

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
@@ -46,7 +46,7 @@ class TotalGhgEmissions extends PureComponent {
           Explore GHG Emissions
         </Button>
         <InfoDownloadToolbox
-          slugs="historical_emissions_cait"
+          slugs="DEA2017b"
           /* downloadUri={} */
           className={styles.buttonWrapper}
         />

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
@@ -12,11 +12,7 @@ import {
 } from 'utils/graphs';
 
 const { COUNTRY_ISO } = process.env;
-const defaults = {
-  gas: 'All GHG',
-  source: 'CAIT',
-  sector: 'Total excluding LUCF'
-};
+const defaults = { gas: 'TotalGHG', source: 'DEA2017b', sector: 'Energy' };
 const getMetaData = ({ metadata = {} }) =>
   metadata.ghg ? metadata.ghg.data : null;
 const getMetricParam = ({ location }) =>
@@ -145,10 +141,10 @@ export const getChartConfig = createSelector(
   }
 );
 
-export const getChartFilters = createSelector(() => [ { label: 'All GHG' } ]);
+export const getChartFilters = createSelector(() => [ { label: 'TotalGHG' } ]);
 
 export const getChartFilterSelected = createSelector(() => [
-  { label: 'All GHG' }
+  { label: 'TotalGHG' }
 ]);
 
 export const getChartData = createStructuredSelector({

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -62,7 +62,7 @@ class GHGHistoricalEmissions extends PureComponent {
     const toolbar = (
       <div className={styles.toolbarButtons}>
         <InfoDownloadToolbox
-          slugs="+++historical_emissions"
+          slugs="DEA2017b"
           className={styles.buttonWrapper}
         />
       </div>

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -12,8 +12,8 @@ import {
 } from 'utils/graphs';
 
 const { COUNTRY_ISO } = process.env;
-const defaults = { gas: 'All GHG', source: 'CAIT' };
-const excludedSectors = [ 'Total excluding LUCF', 'Total including LUCF' ];
+const defaults = { gas: 'TotalGHG', source: 'DEA2017b' };
+const excludedSectors = [ 'Total including FOLU', 'Total excluding FOLU' ];
 
 const getMetaData = ({ metadata = {} }) =>
   metadata.ghg ? metadata.ghg.data : null;

--- a/app/javascript/app/providers/ghg-emissions-provider/ghg-emissions-provider-actions.js
+++ b/app/javascript/app/providers/ghg-emissions-provider/ghg-emissions-provider-actions.js
@@ -1,5 +1,5 @@
 import { createAction, createThunkAction } from 'redux-tools';
-import { CWAPI } from 'services/api';
+import { SAAPI } from 'services/api';
 
 export const fetchGHGEmissionsInit = createAction('fetchGHGEmissionsInit');
 export const fetchGHGEmissionsReady = createAction('fetchGHGEmissionsReady');
@@ -11,10 +11,12 @@ export const fetchGHGEmissions = createThunkAction(
     const { GHGEmissions } = state();
     if (!GHGEmissions.loading) {
       dispatch(fetchGHGEmissionsInit());
-      CWAPI
+      SAAPI
         .get('emissions', params)
         .then((data = {}) => {
-          dispatch(fetchGHGEmissionsReady(data));
+          dispatch(
+            fetchGHGEmissionsReady(data['historicalEmissions::Records'])
+          );
         })
         .catch(error => {
           console.warn(error);

--- a/app/javascript/app/providers/metadata-provider/metadata-provider-actions.js
+++ b/app/javascript/app/providers/metadata-provider/metadata-provider-actions.js
@@ -1,5 +1,5 @@
 import { createAction, createThunkAction } from 'redux-tools';
-import { CWAPI } from 'services/api';
+import { SAAPI } from 'services/api';
 import isArray from 'lodash/isArray';
 import isEmpty from 'lodash/isEmpty';
 
@@ -10,7 +10,7 @@ export const fetchMetaFail = createAction('fetchMetaFail');
 function getDataByMeta(meta) {
   switch (meta) {
     case 'ghg':
-      return CWAPI.get('emissions/meta');
+      return SAAPI.get('emissions/meta');
 
     default:
       return Promise.reject(new Error(

--- a/app/javascript/app/providers/metadata-provider/metadata-provider-reducers.js
+++ b/app/javascript/app/providers/metadata-provider/metadata-provider-reducers.js
@@ -10,28 +10,29 @@ function parseDataByMeta(data, meta) {
   switch (meta) {
     case 'ghg': {
       const dataParsed = {};
-      Object.keys(data).forEach(
+      const leData = data.metadata;
+      Object.keys(leData).forEach(
         key => {
           const camelCasedkey = camelCase(key);
           dataParsed[camelCasedkey] = sortBy(
-            data[key].map(item => {
+            leData[key].map(item => {
               let newItem = {
                 value: item.id,
                 label: key === 'location'
-                  ? item.wri_standard_name.trim()
+                  ? item.wriStandardName.trim()
                   : item.name.trim()
               };
               if (key === 'location') {
-                newItem = { ...newItem, iso: item.iso_code3 };
+                newItem = { ...newItem, iso: item.isoCode3 };
               }
-              if (key === 'data_source') {
+              if (key === 'dataSource') {
                 newItem = {
                   ...newItem,
-                  location: item.location_ids,
-                  sector: item.sector_ids,
-                  gas: item.gas_ids,
-                  gwp: item.gwp_ids,
-                  source: item.source
+                  location: item.locationIds,
+                  sector: item.sectorIds,
+                  gas: item.gasIds,
+                  gwp: item.gwpIds,
+                  source: item.source.replace('historical_emissions_', '')
                 };
               }
               return newItem;

--- a/config/initializers/climate_watch_engine.rb
+++ b/config/initializers/climate_watch_engine.rb
@@ -9,7 +9,5 @@ Locations.location_groupings_filepath = "#{CW_FILES_PREFIX}locations/locations_g
 
 # HistoricalEmissions engine initializer
 require 'historical_emissions'
-HistoricalEmissions.meta_sectors_filepath = "#{CW_FILES_PREFIX}historical_emissions/CW_HistoricalEmissions_metadata_sectors.csv"
-HistoricalEmissions.data_cait_filepath = "#{CW_FILES_PREFIX}historical_emissions/CW_HistoricalEmissions_CAIT.csv"
-HistoricalEmissions.data_pik_filepath = "#{CW_FILES_PREFIX}historical_emissions/CW_HistoricalEmissions_PIK.csv"
-HistoricalEmissions.data_unfccc_filepath = "#{CW_FILES_PREFIX}historical_emissions/CW_HistoricalEmissions_UNFCCC.csv"
+HistoricalEmissions.meta_sectors_filepath = "#{CW_FILES_PREFIX}historical_emissions_metadata_sectors.csv"
+HistoricalEmissions.data_cait_filepath = "#{CW_FILES_PREFIX}historical_emissions_data.csv"

--- a/lib/historical_emissions/engine.rb
+++ b/lib/historical_emissions/engine.rb
@@ -1,0 +1,11 @@
+module HistoricalEmissions
+  class Engine < ::Rails::Engine
+    isolate_namespace HistoricalEmissions
+
+    config.to_prepare do
+      Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").each do |c|
+        require_dependency(c)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds South Africa's GHG emissions data to the project:

- it updates the version of the Climate Watch gem being used;
- adds decorators to handle small differences between Climate Watch and South Africa's source data, as well as the different way we are using the Active Model Serializers;
- Updates frontend code to use now camel case instead of snake case as in the CW API;
- hooks to correct metadata;

I bet some tweaks will still be needed in terms of the default values. 

In terms of the Climate Watch gem and the use of decorators, maybe we can review the Gem to be a little more generic or to allow overriding a few more things, or maybe just describe the decorators in the README file.

I need to merge without review, but creating a PR for async review.