### PR TITLE
Fix/ghg emissions selectors

### DIFF
--- a/app/decorators/serializers/historical_emissions/metadata_serializer_decorator.rb
+++ b/app/decorators/serializers/historical_emissions/metadata_serializer_decorator.rb
@@ -1,0 +1,7 @@
+HistoricalEmissions::MetadataSerializer.class_eval do
+  def sector
+    object.sectors.map do |g|
+      g.slice(:id, :name, :parent_id)
+    end
+  end
+end

--- a/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata-actions.js
@@ -11,7 +11,7 @@ export const setModalMetadata = createThunkAction(
   'setModalMetadata',
   payload => dispatch => {
     dispatch(setModalMetadataParams(payload));
-    let slugs = payload.slugs;
+    let slugs = { payload };
     if (slugs) {
       if (typeof slugs === 'string') slugs = [ slugs ];
       dispatch(fetchModalMetaData(slugs));

--- a/app/javascript/app/pages/financial-resources/support-received/flows-chart/flows-chart-selectors.js
+++ b/app/javascript/app/pages/financial-resources/support-received/flows-chart/flows-chart-selectors.js
@@ -4,6 +4,7 @@ import uniq from 'lodash/uniq';
 import { getFocus, getFocusNames } from 'utils/financial-resources';
 import has from 'lodash/has';
 
+// eslint-disable-next-line react/destructuring-assignment
 const selectData = (state, props) => props.data || null;
 const selectMeta = state =>
   has(state, 'financialResourcesReceived.data.meta') &&

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -34,6 +34,8 @@ class GHGHistoricalEmissions extends PureComponent {
     const {
       sectorSelected,
       sectorOptions,
+      subSectorSelected,
+      subSectorOptions,
       gasSelected,
       gasOptions,
       metricSelected,
@@ -49,6 +51,14 @@ class GHGHistoricalEmissions extends PureComponent {
           values={sectorSelected || []}
           options={sectorOptions || []}
           onValueChange={v => this.handleFieldChange('sector', v)}
+          hideResetButton
+        />
+        <Multiselect
+          label="Sub sector"
+          theme={{ wrapper: styles.dropdown }}
+          values={subSectorSelected || []}
+          options={subSectorOptions || []}
+          onValueChange={v => this.handleFieldChange('subSector', v)}
           hideResetButton
         />
         <Multiselect
@@ -121,6 +131,8 @@ class GHGHistoricalEmissions extends PureComponent {
 }
 GHGHistoricalEmissions.propTypes = {
   chartData: PropTypes.object,
+  subSectorOptions: PropTypes.array,
+  subSectorSelected: PropTypes.array,
   sectorOptions: PropTypes.array,
   sectorSelected: PropTypes.array,
   gasOptions: PropTypes.array,
@@ -135,6 +147,8 @@ GHGHistoricalEmissions.defaultProps = {
   chartData: {},
   sectorOptions: [],
   sectorSelected: null,
+  subSectorOptions: [],
+  subSectorSelected: null,
   gasOptions: [],
   gasSelected: null,
   metricOptions: [],

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -14,10 +14,10 @@ import ModalInfo from 'components/modal-info';
 import styles from './historical-styles';
 
 class GHGHistoricalEmissions extends PureComponent {
-  handleSectorChange = values => {
+  handleFieldChange = (field, values) => {
     const { onFilterChange } = this.props;
     if (values && values.length > 0) {
-      onFilterChange({ sector: values.map(v => v.value).join(',') });
+      onFilterChange({ [field]: values.map(v => v.value).join(',') });
     }
   };
 
@@ -34,6 +34,8 @@ class GHGHistoricalEmissions extends PureComponent {
     const {
       sectorSelected,
       sectorOptions,
+      gasSelected,
+      gasOptions,
       metricSelected,
       metricOptions,
       emissionsParams,
@@ -46,7 +48,15 @@ class GHGHistoricalEmissions extends PureComponent {
           theme={{ wrapper: styles.dropdown }}
           values={sectorSelected || []}
           options={sectorOptions || []}
-          onValueChange={this.handleSectorChange}
+          onValueChange={v => this.handleFieldChange('sector', v)}
+          hideResetButton
+        />
+        <Multiselect
+          label="Gas"
+          theme={{ wrapper: styles.dropdown }}
+          values={gasSelected || []}
+          options={gasOptions || []}
+          onValueChange={v => this.handleFieldChange('gas', v)}
           hideResetButton
         />
         <Dropdown
@@ -113,6 +123,8 @@ GHGHistoricalEmissions.propTypes = {
   chartData: PropTypes.object,
   sectorOptions: PropTypes.array,
   sectorSelected: PropTypes.array,
+  gasOptions: PropTypes.array,
+  gasSelected: PropTypes.array,
   metricOptions: PropTypes.array,
   metricSelected: PropTypes.object,
   emissionsParams: PropTypes.object,
@@ -123,6 +135,8 @@ GHGHistoricalEmissions.defaultProps = {
   chartData: {},
   sectorOptions: [],
   sectorSelected: null,
+  gasOptions: [],
+  gasSelected: null,
   metricOptions: [],
   metricSelected: null,
   emissionsParams: null

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -15,9 +15,25 @@ import styles from './historical-styles';
 
 class GHGHistoricalEmissions extends PureComponent {
   handleFieldChange = (field, values) => {
-    const { onFilterChange } = this.props;
+    const { onFilterChange, sectorOptions } = this.props;
     if (values && values.length > 0) {
-      onFilterChange({ [field]: values.map(v => v.value).join(',') });
+      if (field === 'sector') {
+        const subSectors = [];
+        const sectors = [];
+        values.forEach(v => {
+          if (!sectorOptions.includes(v)) {
+            subSectors.push(v.value);
+          } else {
+            sectors.push(v.value);
+          }
+        });
+        onFilterChange({
+          sector: sectors.join(','),
+          subSector: subSectors.join(',')
+        });
+      } else {
+        onFilterChange({ [field]: values.map(v => v.value).join(',') });
+      }
     }
   };
 

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -21,7 +21,7 @@ class GHGHistoricalEmissions extends PureComponent {
         const subSectors = [];
         const sectors = [];
         values.forEach(v => {
-          if (!sectorOptions.includes(v)) {
+          if (!sectorOptions.map(o => o.label).includes(v.label)) {
             subSectors.push(v.value);
           } else {
             sectors.push(v.value);

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -113,7 +113,7 @@ class GHGHistoricalEmissions extends PureComponent {
               height={450}
               dots={false}
               customMessage="Emissions data not available"
-              onLegendChange={this.handleSectorChange}
+              onLegendChange={v => this.handleFieldChange('sector', v)}
               {...chartData}
             />
           </div>

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -14,6 +14,7 @@ import {
 const { COUNTRY_ISO } = process.env;
 const defaults = { gas: 'TotalGHG', source: 'DEA2017b' };
 const excludedSectors = [ 'Total including FOLU', 'Total excluding FOLU' ];
+const excludedGases = [ 'Total GHG' ];
 
 const getMetaData = ({ metadata = {} }) =>
   metadata.ghg ? metadata.ghg.data : null;
@@ -76,7 +77,7 @@ export const getDataSectors = createSelector([ getEmissionsData ], data => {
 
 export const getGasOptions = createSelector(
   getMetaData,
-  meta => meta && meta.gas || null
+  meta => meta && meta.gas.filter(g => !excludedGases.includes(g.label)) || null
 );
 
 export const getGasSelected = createSelector([ getGasOptions, getGasParam ], (

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -185,6 +185,21 @@ export const parseChartData = createSelector(
   }
 );
 
+const getDataOptions = createSelector(
+  [ getSectorOptions, getSubSectorOptions ],
+  (sectors, subsectors) => {
+    if (!sectors) return null;
+    return sectors.concat(subsectors);
+  }
+);
+
+const getDataSelected = createSelector(
+  [ getSectorSelected, getSubSectorSelected ],
+  (sectors, subsectors) => {
+    if (!sectors) return null;
+    return sectors.concat(subsectors);
+  }
+);
 export const getChartConfig = createSelector(
   [
     getEmissionsData,
@@ -198,17 +213,16 @@ export const getChartConfig = createSelector(
     const sectorSelectedLabels = sectorSelected.map(s => s.label);
     const subSectorSelectedLabels = subSectorSelected.map(s => s.label);
     const gasSelectedLabels = gasSelected && gasSelected.map(s => s.label);
+    const allLabels = sectorSelectedLabels.concat(subSectorSelectedLabels);
+    const getYOption = columns =>
+      columns.map(d => ({ label: d.sector, value: getYColumnValue(d.sector) }));
     const yColumns = data
-      .filter(
-        s =>
-          sectorSelectedLabels
-            .concat(subSectorSelectedLabels)
-            .includes(s.sector)
-      )
-      .filter(s => gasSelectedLabels.includes(s.gas))
-      .map(d => ({ label: d.sector, value: getYColumnValue(d.sector) }));
-    const theme = getThemeConfig(yColumns);
-    const tooltip = getTooltipConfig(yColumns);
+      .filter(s => allLabels.includes(s.sector))
+      .filter(s => gasSelectedLabels.includes(s.gas));
+    const yColumnOptions = getYOption(yColumns);
+    const allColumnOptions = getYOption(data);
+    const theme = getThemeConfig(allColumnOptions);
+    const tooltip = getTooltipConfig(yColumnOptions);
     let { unit } = DEFAULT_AXES_CONFIG.yLeft;
     if (metricSelected.value === METRIC_OPTIONS.PER_GDP.value) {
       unit = `${unit}/ million $ GDP`;
@@ -224,7 +238,7 @@ export const getChartConfig = createSelector(
       theme,
       tooltip,
       animation: false,
-      columns: { x: [ { label: 'year', value: 'x' } ], y: yColumns }
+      columns: { x: [ { label: 'year', value: 'x' } ], y: yColumnOptions }
     };
   }
 );
@@ -233,8 +247,8 @@ export const getChartData = createStructuredSelector({
   data: parseChartData,
   config: getChartConfig,
   loading: getChartLoading,
-  dataOptions: getSectorOptions,
-  dataSelected: getSectorSelected
+  dataOptions: getDataOptions,
+  dataSelected: getDataSelected
 });
 
 export const getTotalGHGEMissions = createStructuredSelector({

--- a/app/javascript/app/providers/metadata-provider/metadata-provider-reducers.js
+++ b/app/javascript/app/providers/metadata-provider/metadata-provider-reducers.js
@@ -20,7 +20,8 @@ function parseDataByMeta(data, meta) {
                 value: item.id,
                 label: key === 'location'
                   ? item.wriStandardName.trim()
-                  : item.name.trim()
+                  : item.name.trim(),
+                ...(item.parentId && { parentId: item.parentId })
               };
               if (key === 'location') {
                 newItem = { ...newItem, iso: item.isoCode3 };
@@ -42,6 +43,7 @@ function parseDataByMeta(data, meta) {
         },
         this
       );
+
       return dataParsed;
     }
 

--- a/app/javascript/app/providers/metadata-provider/metadata-provider.js
+++ b/app/javascript/app/providers/metadata-provider/metadata-provider.js
@@ -7,7 +7,8 @@ import reducers, { initialState } from './metadata-provider-reducers';
 
 class MetaProvider extends PureComponent {
   componentDidMount() {
-    this.props.fetchMeta(this.props.meta);
+    const { fetchMeta, meta } = this.props;
+    fetchMeta(meta);
   }
 
   render() {

--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -43,7 +43,17 @@ export const CHART_COLORS = [
   '#AB0000',
   '#20D5B7',
   '#383F45',
-  '#CACCD0'
+  '#CACCD0',
+  '#80DAE9',
+  '#93BBD9',
+  '#E98CBE',
+  '#FFDA80',
+  '#FFBC80',
+  '#FFC4D5',
+  '#D58080',
+  '#90EADB',
+  '#9C9FA2',
+  '#E5E6E8'
 ];
 
 export const getThemeConfig = (columns, colors = CHART_COLORS) => {


### PR DESCRIPTION
This PR:

- Adds gases selector and filters
- Adds subsector selector, splits sectors and subsectors

Notes:
- 'Total GHG' gas is excluded as we already have 'TotalGHG' with data
- Right now we only have gas data in 'TotalGHG'
- Maybe we could improve the multiselect in the case that we have only one item selected showing that item instead of '1 selected'
- I tried to extract nested selector but is still in process in a branch in cw-components

![image](https://user-images.githubusercontent.com/9701591/47713586-f0be0900-dc3a-11e8-9fd2-1a2d6325fc8c.png)
