### PR TITLE
Group files by sector folders

### DIFF
--- a/app/admin/south_africa_platform/financial_resources.rb
+++ b/app/admin/south_africa_platform/financial_resources.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register_page 'South Africa Platform Financial Resources' do
     end
 
     def s3_folder_path
-      CW_FILES_PREFIX.chop
+      "#{CW_FILES_PREFIX}financial_resources"
     end
 
     def path

--- a/app/admin/south_africa_platform/ghg_emissions.rb
+++ b/app/admin/south_africa_platform/ghg_emissions.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register_page 'South Africa Platform Ghg Emissions' do
     end
 
     def s3_folder_path
-      CW_FILES_PREFIX.chop
+      "#{CW_FILES_PREFIX}ghg_emissions"
     end
 
     def path

--- a/app/admin/south_africa_platform/historical_emissions.rb
+++ b/app/admin/south_africa_platform/historical_emissions.rb
@@ -1,0 +1,71 @@
+ActiveAdmin.register_page 'South Africa Platform Historical Emissions' do
+  include DataUploader::SharedAdmin
+
+  section_name = 'historical_emissions'
+  platform_name = 'south_africa_platform'
+
+  controller do
+    def section_name
+      'historical_emissions'
+    end
+
+    def platform_name
+      'south_africa_platform'
+    end
+
+    def s3_folder_path
+      "#{CW_FILES_PREFIX}historical_emissions"
+    end
+
+    def path
+      admin_south_africa_platform_historical_emissions_path
+    end
+
+    def section
+      section_repository.filter_by_section_and_platform(
+        section_name,
+        platform_name
+      )
+    end
+
+    def import_worker
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportHistoricalEmissions')
+    end
+
+    def section_repository
+      @section_repository ||= DataUploader::Repositories::SectionRepository.new
+    end
+
+    def dataset_repository
+      @dataset_repository ||= DataUploader::Repositories::DatasetRepository.new
+    end
+  end
+
+  menu parent: 'South Africa Platform',
+       label: section_name.split('_').map(&:capitalize).join(' '),
+       if: proc { DataUploader::Helpers::Ability.can_view?(platform_name) }
+
+  section_proc = proc {
+    DataUploader::Repositories::SectionRepository.new.filter_by_section_and_platform(
+      section_name,
+      platform_name
+    )
+  }
+
+  datasets_proc = proc {
+    DataUploader::Repositories::DatasetRepository.new.filter_by_section(section_proc.call.id)
+  }
+
+  content do
+    render partial: 'data_uploader/admin/form_upload_datasets', locals: {
+      datasets: datasets_proc.call,
+      upload_path: admin_south_africa_platform_historical_emissions_upload_datafile_path,
+      download_path: admin_south_africa_platform_historical_emissions_download_datafiles_path,
+      download_single_data_file_path:
+          admin_south_africa_platform_historical_emissions_download_datafile_path,
+      import_path: admin_south_africa_platform_historical_emissions_run_importer_path,
+      import_button_disabled: section_proc.call.worker_logs.started.any?,
+      logs: section_proc.call.worker_logs.order(created_at: :desc)
+    }
+  end
+end

--- a/app/admin/south_africa_platform/inventory_improvement.rb
+++ b/app/admin/south_africa_platform/inventory_improvement.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register_page 'South Africa Platform Inventory Improvement' do
     end
 
     def s3_folder_path
-      CW_FILES_PREFIX.chop
+      "#{CW_FILES_PREFIX}inventory_improvement"
     end
 
     def path

--- a/app/admin/south_africa_platform/metadata.rb
+++ b/app/admin/south_africa_platform/metadata.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register_page 'South Africa Platform Metadata' do
     end
 
     def s3_folder_path
-      CW_FILES_PREFIX.chop
+      "#{CW_FILES_PREFIX}metadata"
     end
 
     def path

--- a/app/admin/south_africa_platform/mitigation_actions.rb
+++ b/app/admin/south_africa_platform/mitigation_actions.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register_page 'South Africa Platform Mitigation Actions' do
     end
 
     def s3_folder_path
-      CW_FILES_PREFIX.chop
+      "#{CW_FILES_PREFIX}mitigation_actions"
     end
 
     def path

--- a/app/admin/south_africa_platform/national_circumstances.rb
+++ b/app/admin/south_africa_platform/national_circumstances.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register_page 'South Africa Platform National Circumstances' do
     end
 
     def s3_folder_path
-      CW_FILES_PREFIX.chop
+      "#{CW_FILES_PREFIX}national_circumstances"
     end
 
     def path

--- a/app/services/import_data_source.rb
+++ b/app/services/import_data_source.rb
@@ -1,6 +1,6 @@
 class ImportDataSource
   DATA_FILEPATH =
-    "#{CW_FILES_PREFIX}data_sources.csv".freeze
+    "#{CW_FILES_PREFIX}metadata/data_sources.csv".freeze
 
   def call
     cleanup

--- a/app/services/import_financial_resource.rb
+++ b/app/services/import_financial_resource.rb
@@ -1,7 +1,7 @@
 class ImportFinancialResource
-  SUPPORT_NEEDS_FILEPATH = "#{CW_FILES_PREFIX}support_needs.csv".freeze
-  RECEIVED_SUPPORTS_FILEPATH = "#{CW_FILES_PREFIX}support_received.csv".freeze
-  INDICATORS_FILEPATH = "#{CW_FILES_PREFIX}financial_indicators.csv".freeze
+  SUPPORT_NEEDS_FILEPATH = "#{CW_FILES_PREFIX}financial_resources/support_needs.csv".freeze
+  RECEIVED_SUPPORTS_FILEPATH = "#{CW_FILES_PREFIX}financial_resources/support_received.csv".freeze
+  INDICATORS_FILEPATH = "#{CW_FILES_PREFIX}financial_resources/financial_indicators.csv".freeze
 
   def call
     cleanup

--- a/app/services/import_ghg.rb
+++ b/app/services/import_ghg.rb
@@ -1,7 +1,7 @@
 class ImportGhg
-  PROJECTED_EMISSIONS_FILEPATH = "#{CW_FILES_PREFIX}projected_emissions.csv".freeze
+  PROJECTED_EMISSIONS_FILEPATH = "#{CW_FILES_PREFIX}ghg_emissions/projected_emissions.csv".freeze
   PROJECTED_EMISSIONS_METADATA_FILEPATH =
-    "#{CW_FILES_PREFIX}projected_emissions_metadata.csv".freeze
+    "#{CW_FILES_PREFIX}ghg_emissions/projected_emissions_metadata.csv".freeze
 
   def call
     cleanup

--- a/app/services/import_inventory_improvement.rb
+++ b/app/services/import_inventory_improvement.rb
@@ -1,6 +1,6 @@
 class ImportInventoryImprovement
   DATA_FILEPATH =
-    "#{CW_FILES_PREFIX}inventory_improvement_projects.csv".freeze
+    "#{CW_FILES_PREFIX}inventory_improvement/inventory_improvement_projects.csv".freeze
 
   def call
     cleanup

--- a/app/services/import_mitigation.rb
+++ b/app/services/import_mitigation.rb
@@ -1,9 +1,9 @@
 class ImportMitigation
-  MITIGATION_ACTIONS_FILEPATH = "#{CW_FILES_PREFIX}mitigation_actions.csv".freeze
-  MITIGATION_EFFECTS_FILEPATH = "#{CW_FILES_PREFIX}mitigation_effects.csv".freeze
-  MITIGATION_INDICATORS_FILEPATH = "#{CW_FILES_PREFIX}mitigation_indicators.csv".freeze
-  FLAGSHIP_PROGRAMMES_FILEPATH = "#{CW_FILES_PREFIX}flagship_programmes.csv".freeze
-  FLAGSHIP_COMPONENTS_FILEPATH = "#{CW_FILES_PREFIX}flagship_components.csv".freeze
+  MITIGATION_ACTIONS_FILEPATH = "#{CW_FILES_PREFIX}mitigation_actions/mitigation_actions.csv".freeze
+  MITIGATION_EFFECTS_FILEPATH = "#{CW_FILES_PREFIX}mitigation_actions/mitigation_effects.csv".freeze
+  MITIGATION_INDICATORS_FILEPATH = "#{CW_FILES_PREFIX}mitigation_actions/mitigation_indicators.csv".freeze
+  FLAGSHIP_PROGRAMMES_FILEPATH = "#{CW_FILES_PREFIX}mitigation_actions/flagship_programmes.csv".freeze
+  FLAGSHIP_COMPONENTS_FILEPATH = "#{CW_FILES_PREFIX}mitigation_actions/flagship_components.csv".freeze
 
   def call
     cleanup

--- a/app/services/import_national_circumstances.rb
+++ b/app/services/import_national_circumstances.rb
@@ -1,7 +1,7 @@
 class ImportNationalCircumstances
-  PRIORITIES_FILEPATH = "#{CW_FILES_PREFIX}priorities.csv".freeze
-  INDICATORS_FILEPATH = "#{CW_FILES_PREFIX}national_circumstances_indicators.csv".freeze
-  NATIONAL_CIRCUMSTANCES_FILEPATH = "#{CW_FILES_PREFIX}national_circumstances.csv".freeze
+  PRIORITIES_FILEPATH = "#{CW_FILES_PREFIX}national_circumstances/priorities.csv".freeze
+  INDICATORS_FILEPATH = "#{CW_FILES_PREFIX}national_circumstances/national_circumstances_indicators.csv".freeze
+  NATIONAL_CIRCUMSTANCES_FILEPATH = "#{CW_FILES_PREFIX}national_circumstances/national_circumstances.csv".freeze
 
   def call
     cleanup

--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -1,11 +1,16 @@
 platforms:
   - name: south_africa_platform
     sections:
+      - name: historical_emissions
+        importer: ImportHistoricalEmissions
+        datasets:
+          - historical_emissions_metadata_sectors
+          - historical_emissions_data
       - name: metadata
         importer: ImportDataSource
         datasets:
           - data_sources
-      - name: financial_resources
+      - name: financial_resources 
         importer: ImportFinancialResource
         datasets:
           - support_needs

--- a/config/initializers/climate_watch_engine.rb
+++ b/config/initializers/climate_watch_engine.rb
@@ -9,5 +9,5 @@ Locations.location_groupings_filepath = "#{CW_FILES_PREFIX}locations/locations_g
 
 # HistoricalEmissions engine initializer
 require 'historical_emissions'
-HistoricalEmissions.meta_sectors_filepath = "#{CW_FILES_PREFIX}historical_emissions_metadata_sectors.csv"
-HistoricalEmissions.data_cait_filepath = "#{CW_FILES_PREFIX}historical_emissions_data.csv"
+HistoricalEmissions.meta_sectors_filepath = "#{CW_FILES_PREFIX}historical_emissions/historical_emissions_metadata_sectors.csv"
+HistoricalEmissions.data_cait_filepath = "#{CW_FILES_PREFIX}historical_emissions/historical_emissions_data.csv"


### PR DESCRIPTION
* Group files the way data uploader gem expects them to be; group by sectors
* Modify importers and change back the admin pages to the way they're generated with a rake task
* Testable; files are already grouped like that in S3
* That also fixes broken `Download files` button