### PR TITLE
Updated cw_historical_emissions to version with CSV support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,14 +55,14 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 git 'https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git' do
-  gem 'climate_watch_engine', '~> 1.3.1'
-  gem 'cw_locations', '~> 1.3.0', require: 'locations'
-  gem 'cw_historical_emissions', '~> 1.3.1', require: 'historical_emissions'
+  gem 'climate_watch_engine', '~> 1.3.2'
+  gem 'cw_locations', '~> 1.3.1', require: 'locations'
+  gem 'cw_historical_emissions', '~> 1.3.2', require: 'historical_emissions'
   gem 'cw_data_uploader', '~> 0.3.0', require: 'data_uploader'
 end
 
 # for debugging
-# gem 'climate_watch_engine', '~> 1.3.1', path: '../climate-watch-gems'
+# gem 'climate_watch_engine', '~> 1.3.2', path: '../climate-watch-gems'
 # gem 'cw_locations', '~> 1.3.1', require: 'locations', path: '../climate-watch-gems'
-# gem 'cw_historical_emissions', '~> 1.3.1', require: 'historical_emissions', path: '../climate-watch-gems'
-# gem 'cw_data_uploader', '~> 0.2.1', require: 'data_uploader', path: '../climate-watch-gems'
+# gem 'cw_historical_emissions', '~> 1.3.2', require: 'historical_emissions', path: '../climate-watch-gems'
+# gem 'cw_data_uploader', '~> 0.3.0', require: 'data_uploader', path: '../climate-watch-gems'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git
-  revision: 7010d5b0d7985457004fe36f65d87dfafd39040e
+  revision: 8a1f360d80b42903f6d65cb3e50e954f89a01a3b
   specs:
-    climate_watch_engine (1.3.1)
+    climate_watch_engine (1.3.2)
       aws-sdk-s3 (~> 1)
       rails (~> 5.2.0)
     cw_data_uploader (0.3.0)
@@ -13,14 +13,14 @@ GIT
       devise
       pg
       sidekiq
-    cw_historical_emissions (1.3.1)
+    cw_historical_emissions (1.3.2)
       active_model_serializers (~> 0.10.0)
       aws-sdk-s3 (~> 1)
-      climate_watch_engine (~> 1.3.0)
-      cw_locations (~> 1.3.0)
+      climate_watch_engine (~> 1.3.2)
+      cw_locations (~> 1.3.1)
       pg
       rails (~> 5.2.0)
-    cw_locations (1.3.0)
+    cw_locations (1.3.1)
       active_model_serializers (~> 0.10.0)
       aws-sdk-s3 (~> 1)
       climate_watch_engine (~> 1.3.0)
@@ -53,7 +53,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_model_serializers (0.10.7)
+    active_model_serializers (0.10.8)
       actionpack (>= 4.1, < 6)
       activemodel (>= 4.1, < 6)
       case_transform (>= 0.2)
@@ -139,7 +139,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.2)
     connection_pool (2.2.2)
     crass (1.0.4)
     devise (4.5.0)
@@ -210,7 +210,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    method_source (0.9.0)
+    method_source (0.9.1)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
@@ -223,7 +223,7 @@ GEM
     pg (1.1.3)
     public_suffix (3.0.2)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.4)
       rack
     rack-proxy (0.6.4)
@@ -358,10 +358,10 @@ DEPENDENCIES
   annotate
   byebug
   capybara (~> 2.13)
-  climate_watch_engine (~> 1.3.1)!
+  climate_watch_engine (~> 1.3.2)!
   cw_data_uploader (~> 0.3.0)!
-  cw_historical_emissions (~> 1.3.1)!
-  cw_locations (~> 1.3.0)!
+  cw_historical_emissions (~> 1.3.2)!
+  cw_locations (~> 1.3.1)!
   devise
   dotenv-rails
   factory_bot_rails
@@ -385,4 +385,4 @@ DEPENDENCIES
   webpacker
 
 BUNDLED WITH
-   1.16.5
+   1.17.1


### PR DESCRIPTION
Uses a version of the gem that adds a csv download similar to the one in Data Explorer.

https://github.com/ClimateWatch-Vizzuality/climate-watch-gems/pull/13


To test:
/api/v1/emissions/meta - gives you available sources

/api/v1/emissions.csv?source=[id of DEA2017b]&location=ZAF