### PR TITLE
Content management integration

### DIFF
--- a/app/admin/content_management.rb
+++ b/app/admin/content_management.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register SectionContent do
   actions :all, except: [:destroy, :create, :new]
   config.filters = false
+  config.sort_order = 'order_asc'
   permit_params :title, :description
 
   form do |f|

--- a/app/admin/content_management.rb
+++ b/app/admin/content_management.rb
@@ -3,24 +3,11 @@ ActiveAdmin.register SectionContent do
   config.filters = false
   permit_params :title, :description
 
-  controller do
-    def scoped_collection
-      SectionContent.where(subsection_id: nil)
-    end
-  end
-
   form do |f|
     f.inputs 'Main Section' do
       f.input :name, input_html: {readonly: true}
       f.input :title, label: 'Title'
       f.input :description, label: 'Description'
-    end
-    f.inputs 'Subsections' do
-      f.has_many :subsections, new_record: false, allow_destroy: false do |a|
-        a.input :name, input_html: {readonly: true}
-        a.input :title
-        a.input :description
-      end
     end
     f.actions
   end
@@ -39,11 +26,13 @@ ActiveAdmin.register SectionContent do
       column :title
       column :description
     end
-    h3 'Subsections'
-    table_for section_content.subsections do
-      column :name
-      column :title
-      column :description
+    unless section_content.subsections.empty?
+      h3 'Subsections'
+      table_for section_content.subsections do
+        column :name
+        column :title
+        column :description
+      end
     end
   end
 end

--- a/app/javascript/app/components/home/flagship-programmes/flagship-programmes-component.jsx
+++ b/app/javascript/app/components/home/flagship-programmes/flagship-programmes-component.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import Link from 'redux-first-router-link';
 import { Stories, Button } from 'cw-components';
 import SectionTitle from 'components/section-title';
@@ -9,12 +10,13 @@ import { flagshipProgrammes } from './flagship-programmes-map';
 
 class FlagshipProgrammes extends PureComponent {
   render() {
+    const { title, description } = this.props;
     return (
       <div className={styles.flagshipContainer}>
         <div className="layout-container">
           <div className={styles.titleContainer}>
             <SectionTitle
-              title="Flagship Programmes"
+              title={title}
               theme={{ sectionTitle: styles.flagshipProgrammesTitle }}
             />
             <div className={styles.buttonContainer}>
@@ -38,12 +40,17 @@ class FlagshipProgrammes extends PureComponent {
           </div>
         </div>
         <p className={styles.description}>
-          The Climate Change Flagship Programmes are strategic measures implemented by the South African government to trigger a large-scale transition to a low-carbon economy and create a more climate-resilient South Africa. They signal climate change investment priorities and provide the certainty needed to stimulate further investment.
+          {description}
         </p>
         <Stories stories={flagshipProgrammes} theme={styles} />
       </div>
     );
   }
 }
+
+FlagshipProgrammes.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
+};
 
 export default FlagshipProgrammes;

--- a/app/javascript/app/components/home/flagship-programmes/flagship-programmes.js
+++ b/app/javascript/app/components/home/flagship-programmes/flagship-programmes.js
@@ -1,3 +1,14 @@
+import { connect } from 'react-redux';
 import Component from './flagship-programmes-component';
 
-export default Component;
+const mapStateToProps = ({ SectionsContent }) => {
+  const { data } = SectionsContent;
+  return {
+    title: data && data.flagship_programmes && data.flagship_programmes.title,
+    description: data &&
+      data.flagship_programmes &&
+      data.flagship_programmes.description
+  };
+};
+
+export default connect(mapStateToProps, null)(Component);

--- a/app/javascript/app/components/home/ndc-pledge/ndc-pledge-component.jsx
+++ b/app/javascript/app/components/home/ndc-pledge/ndc-pledge-component.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import SectionTitle from 'components/section-title';
 import { Button } from 'cw-components';
 import button from 'styles/themes/button';
@@ -12,21 +13,16 @@ class NDCPledge extends PureComponent {
   };
 
   render() {
+    const { title, description } = this.props;
     return (
       <div className={styles.ndcContainer}>
         <div className={styles.ndcImage} />
         <div className={styles.ndcTextContainer}>
-          <SectionTitle
-            isSubtitle
-            className={styles.ndcTitle}
-            title="South Africa National Determined Contribution (NDC) pledge and ambition"
+          <SectionTitle isSubtitle className={styles.ndcTitle} title={title} />
+          <p
+            className={styles.ndcDescription}
+            dangerouslySetInnerHTML={{ __html: description }}
           />
-          <p className={styles.ndcDescription}>
-            Under South Africa’s NDC,  GHG emissions will peak between 2020 and 2025, plateau for approximately a decade, landing in the range of 398-614 MtCO2eq as defined by national policy, and decline in absolute terms thereafter.
-          </p>
-          <p className={styles.ndcDescription}>
-            The adaptation component of South Africa’s NDC will address adaptation through six goals, underpinned by key elements of adaptation planning, pricing of adaptation investment requirements, equity, and means of implementation.
-          </p>
           <Button
             onClick={this.handleNDCPledgeClick}
             theme={{ button: cx(button.white, styles.learnMoreButton) }}
@@ -38,5 +34,8 @@ class NDCPledge extends PureComponent {
     );
   }
 }
-NDCPledge.propTypes = {};
+NDCPledge.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
+};
 export default NDCPledge;

--- a/app/javascript/app/components/home/ndc-pledge/ndc-pledge.js
+++ b/app/javascript/app/components/home/ndc-pledge/ndc-pledge.js
@@ -1,3 +1,12 @@
+import { connect } from 'react-redux';
 import Component from './ndc-pledge-component';
 
-export default Component;
+const mapStateToProps = ({ SectionsContent }) => {
+  const { data } = SectionsContent;
+  return {
+    title: data && data.ndc_submission && data.ndc_submission.title,
+    description: data && data.ndc_submission && data.ndc_submission.description
+  };
+};
+
+export default connect(mapStateToProps, null)(Component);

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
@@ -23,7 +23,8 @@ class TotalGhgEmissions extends PureComponent {
       metricSelected,
       metricOptions,
       emissionsParams,
-      chartData
+      chartData,
+      contentData
     } = this.props;
 
     const dropdown = (
@@ -56,11 +57,11 @@ class TotalGhgEmissions extends PureComponent {
       <React.Fragment>
         <Section theme={styles}>
           <SectionTitle
-            title="Historical Emissions"
+            title={contentData.title}
             theme={{ sectionTitle: styles.title }}
           />
           <p className={styles.description}>
-            South Africa’s National GHG inventory for the period 2000-2014 was compiled according to the IPCC-2006 guidelines and covers four emission sectors: Energy; Industrial Processes and Product Use; Agriculture, Forestry and Other Land Use; and Waste.
+            {contentData.description}
           </p>
           <TabletLandscape>
             {matches => {
@@ -100,12 +101,17 @@ TotalGhgEmissions.propTypes = {
   metricOptions: PropTypes.array,
   metricSelected: PropTypes.object,
   emissionsParams: PropTypes.object,
-  updateMetricSelected: PropTypes.func.isRequired
+  updateMetricSelected: PropTypes.func.isRequired,
+  contentData: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string
+  })
 };
 TotalGhgEmissions.defaultProps = {
   chartData: {},
   metricOptions: [],
   metricSelected: null,
-  emissionsParams: null
+  emissionsParams: null,
+  contentData: {}
 };
 export default TotalGhgEmissions;

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
@@ -24,6 +24,9 @@ const getEmissionsData = ({ GHGEmissions = {} }) =>
 const getChartLoading = ({ metadata = {}, GHGEmissions = {} }) =>
   metadata.ghg.loading || GHGEmissions.loading;
 
+const getSectionContent = ({ SectionsContent }) =>
+  SectionsContent.data && SectionsContent.data.historical_emissions;
+
 const getGas = createSelector(getMetaData, meta => {
   if (!meta || !meta.gas) return null;
   const selected = meta.gas.find(gas => gas.label === defaults.gas);
@@ -147,6 +150,17 @@ export const getChartFilterSelected = createSelector(() => [
   { label: 'TotalGHG' }
 ]);
 
+const getTitleAndDescription = createSelector(
+  [ getSectionContent ],
+  sectionContent => {
+    const content = {
+      title: sectionContent && sectionContent.title,
+      description: sectionContent && sectionContent.description
+    };
+    return content;
+  }
+);
+
 export const getChartData = createStructuredSelector({
   data: parseChartData,
   config: getChartConfig,
@@ -159,5 +173,6 @@ export const getTotalGHGEMissions = createStructuredSelector({
   metricOptions: getMetricOptions,
   metricSelected: getMetricSelected,
   emissionsParams: getEmissionsParams,
-  chartData: getChartData
+  chartData: getChartData,
+  contentData: getTitleAndDescription
 });

--- a/app/javascript/app/components/section-title/section-title-component.jsx
+++ b/app/javascript/app/components/section-title/section-title-component.jsx
@@ -12,31 +12,54 @@ class SectionTitle extends PureComponent {
   };
 
   render() {
-    const { theme, title, isSubtitle, infoButton, className } = this.props;
+    const {
+      theme,
+      title,
+      isSubtitle,
+      infoButton,
+      className,
+      description,
+      noMarginBottom
+    } = this.props;
     return (
-      <div className={styles.sectionTitleContainer}>
-        <h2
-          className={cx(
-            styles.sectionTitle,
-            { [styles.sectionSubtitle]: isSubtitle },
-            theme.sectionTitle,
-            className
-          )}
-        >
-          {title}
-        </h2>
-        {
-          infoButton && (
-          <button
-            onClick={this.handleInfoClick}
-            className={cx(styles.iconContainer, theme.iconContainer)}
-            type="button"
+      <React.Fragment>
+        <div className={styles.sectionTitleContainer}>
+          <h2
+            className={cx(
+              styles.sectionTitle,
+              { [styles.sectionSubtitle]: isSubtitle },
+              {
+                [styles.sectionContainerNoMarginBottom]: description ||
+                  noMarginBottom
+              },
+              theme.sectionTitle,
+              className
+            )}
           >
-            <Icon icon={iconInfo} />
-          </button>
+            {title}
+          </h2>
+          {
+            infoButton && (
+            <button
+              onClick={this.handleInfoClick}
+              className={cx(styles.iconContainer, theme.iconContainer)}
+              type="button"
+            >
+              <Icon icon={iconInfo} />
+            </button>
+              )
+          }
+        </div>
+        {
+          description &&
+            (
+              <p
+                className={styles.sectionDescription}
+                dangerouslySetInnerHTML={{ __html: description }}
+              />
             )
         }
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -47,7 +70,9 @@ SectionTitle.propTypes = {
   infoButton: PropTypes.bool,
   className: PropTypes.string,
   isSubtitle: PropTypes.bool,
-  setOpen: PropTypes.func.isRequired
+  setOpen: PropTypes.func.isRequired,
+  description: PropTypes.string,
+  noMarginBottom: PropTypes.bool
 };
 
 SectionTitle.defaultProps = {
@@ -55,7 +80,9 @@ SectionTitle.defaultProps = {
   title: '',
   isSubtitle: false,
   infoButton: false,
-  className: null
+  className: null,
+  description: '',
+  noMarginBottom: false
 };
 
 export default SectionTitle;

--- a/app/javascript/app/components/section-title/section-title-styles.scss
+++ b/app/javascript/app/components/section-title/section-title-styles.scss
@@ -25,3 +25,15 @@
 .iconContainer {
   margin: ($gutter-padding + 8px) 0 0 10px;
 }
+
+.sectionDescription {
+  font-size: $font-size;
+  color: $midnightblue;
+  line-height: 1.38;
+  margin-bottom: 20px;
+  padding-bottom: $gutter-padding;
+}
+
+.sectionContainerNoMarginBottom {
+  margin-bottom: 0;
+}

--- a/app/javascript/app/layouts/sections/sections-component.jsx
+++ b/app/javascript/app/layouts/sections/sections-component.jsx
@@ -7,6 +7,7 @@ import lowerCase from 'lodash/lowerCase';
 import capitalize from 'lodash/capitalize';
 import Nav from 'components/nav';
 import navStyles from 'components/nav/nav-styles';
+import SectionsContentProvider from 'providers/sections-content-provider';
 
 import ghgEmissionsBg from 'assets/backgrounds/ghg-emissions';
 import nationalBg from 'assets/backgrounds/national-circumstances';
@@ -40,9 +41,10 @@ class Sections extends PureComponent {
   }
 
   render() {
-    const { route, section, payload } = this.props;
-    const title = route.label || capitalize(lowerCase(payload.id));
-    const description = route.description;
+    const { route, section, payload, contentData } = this.props;
+    const title = (contentData[route.parentSection] && contentData[route.parentSection].title) || capitalize(lowerCase(payload.id));
+    const description = contentData[route.parentSection] && contentData[route.parentSection].description;
+    const subsectionTitle = contentData[section.slug] && contentData[section.slug].title;
     return (
       <div className={styles.page}>
         <div className={styles.section} style={{ backgroundImage: `url('${backgrounds[route.link]}')`}}>
@@ -57,7 +59,8 @@ class Sections extends PureComponent {
             </div>
           </Sticky>
         </div>
-        <SectionComponent page={route.link} section={section.slug} />
+        <SectionComponent page={route.link} section={section.slug} title={subsectionTitle} />
+        <SectionsContentProvider />
       </div>
     );
   }
@@ -67,6 +70,7 @@ Sections.propTypes = {
   route: PropTypes.object.isRequired,
   payload: PropTypes.object.isRequired,
   section: PropTypes.object.isRequired,
+  contentData: PropTypes.object.isRequired
 }
 
 export default Sections;

--- a/app/javascript/app/layouts/sections/sections-component.jsx
+++ b/app/javascript/app/layouts/sections/sections-component.jsx
@@ -45,6 +45,7 @@ class Sections extends PureComponent {
     const title = (contentData[route.parentSection] && contentData[route.parentSection].title) || capitalize(lowerCase(payload.id));
     const description = contentData[route.parentSection] && contentData[route.parentSection].description;
     const subsectionTitle = contentData[section.slug] && contentData[section.slug].title;
+    const subsectionDesc = contentData[section.slug] && contentData[section.slug].description;
     return (
       <div className={styles.page}>
         <div className={styles.section} style={{ backgroundImage: `url('${backgrounds[route.link]}')`}}>
@@ -59,7 +60,7 @@ class Sections extends PureComponent {
             </div>
           </Sticky>
         </div>
-        <SectionComponent page={route.link} section={section.slug} title={subsectionTitle} />
+        <SectionComponent page={route.link} section={section.slug} title={subsectionTitle} description={subsectionDesc} />
         <SectionsContentProvider />
       </div>
     );

--- a/app/javascript/app/layouts/sections/sections.js
+++ b/app/javascript/app/layouts/sections/sections.js
@@ -13,7 +13,7 @@ const getSectionsWithReplacedIds = (sections, prevPayloadId, payloadId) => {
   });
 };
 
-const mapStateToProps = ({ location }) => {
+const mapStateToProps = ({ location, SectionsContent }) => {
   const route = location.routesMap[location.type];
   const { section: currentSectionSlug } = location.payload;
   let section = null;
@@ -27,7 +27,12 @@ const mapStateToProps = ({ location }) => {
       location.payload.id
     );
   }
-  return { route, section, payload: location.payload };
+  return {
+    route,
+    section,
+    payload: location.payload,
+    contentData: SectionsContent.data
+  };
 };
 
 export default connect(mapStateToProps, null)(PlanningComponent);

--- a/app/javascript/app/pages/financial-resources/support-needed/support-needed-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-needed/support-needed-component.jsx
@@ -42,11 +42,11 @@ class SupportNeeded extends PureComponent {
   }
 
   render() {
-    const { searchFilter, activeTabValue } = this.props;
+    const { searchFilter, activeTabValue, title } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title="Support Needed" infoButton />
-        <ModalInfo title="Support Needed">
+        <SectionTitle isSubtitle title={title} infoButton />
+        <ModalInfo title={title}>
           This section includes a summary of support needed for climate change mitigation and adaptation actions.
         </ModalInfo>
         <TabSwitcher
@@ -70,7 +70,8 @@ SupportNeeded.propTypes = {
   searchFilter: PropTypes.string,
   activeTabValue: PropTypes.string,
   updateQueryParam: PropTypes.func.isRequired,
-  tableData: PropTypes.object
+  tableData: PropTypes.object,
+  title: PropTypes.string.isRequired
 };
 
 SupportNeeded.defaultProps = {

--- a/app/javascript/app/pages/financial-resources/support-needed/support-needed-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-needed/support-needed-component.jsx
@@ -4,7 +4,6 @@ import SectionTitle from 'components/section-title';
 import TabSwitcher from 'components/tab-switcher';
 import DataTable from 'components/data-table';
 import FinancialResourcesNeededProvider from 'providers/financial-resources-needed-provider';
-import ModalInfo from 'components/modal-info';
 import styles from './support-needed-styles.scss';
 
 const FINANCIAL_SUPPORT_NEEDED_KEY = 'financialSupportNeeded';
@@ -42,13 +41,10 @@ class SupportNeeded extends PureComponent {
   }
 
   render() {
-    const { searchFilter, activeTabValue, title } = this.props;
+    const { searchFilter, activeTabValue, title, description } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title={title} infoButton />
-        <ModalInfo title={title}>
-          This section includes a summary of support needed for climate change mitigation and adaptation actions.
-        </ModalInfo>
+        <SectionTitle isSubtitle title={title} description={description} />
         <TabSwitcher
           tabs={this.renderTabs()}
           searchFilter={searchFilter}
@@ -71,7 +67,8 @@ SupportNeeded.propTypes = {
   activeTabValue: PropTypes.string,
   updateQueryParam: PropTypes.func.isRequired,
   tableData: PropTypes.object,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 
 SupportNeeded.defaultProps = {

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
@@ -70,7 +70,7 @@ class SupportReceived extends PureComponent {
   }
 
   render() {
-    const { activeTabValue, data } = this.props;
+    const { activeTabValue, data, title } = this.props;
     const component = this.renderChartComponent();
     const renderTabs = [
       { name: 'INTERNATIONAL', value: INTERNATIONAL_KEY, component },
@@ -89,8 +89,8 @@ class SupportReceived extends PureComponent {
 
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title="Support Received" infoButton />
-        <ModalInfo title="Support Received">
+        <SectionTitle isSubtitle title={title} infoButton />
+        <ModalInfo title={title}>
           The financial support committed and received from international sources, as well as domestic funds committed through government grants and loans, are reported below.
         </ModalInfo>
         <TabSwitcher
@@ -117,7 +117,8 @@ SupportReceived.propTypes = {
   options: PropTypes.object,
   values: PropTypes.object,
   dropdownConfig: PropTypes.array,
-  data: PropTypes.array
+  data: PropTypes.array,
+  title: PropTypes.string.isRequired
 };
 
 SupportReceived.defaultProps = {

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
@@ -4,7 +4,6 @@ import SectionTitle from 'components/section-title';
 import TabSwitcher from 'components/tab-switcher';
 import { Dropdown } from 'cw-components';
 import FinancialResourcesReceivedProvider from 'providers/financial-resources-received-provider/financial-resources-received-provider';
-import ModalInfo from 'components/modal-info';
 import styles from './support-received-styles.scss';
 import FlowsChart from './flows-chart';
 import ComparisonChart from './comparison-chart';
@@ -70,7 +69,7 @@ class SupportReceived extends PureComponent {
   }
 
   render() {
-    const { activeTabValue, data, title } = this.props;
+    const { activeTabValue, data, title, description } = this.props;
     const component = this.renderChartComponent();
     const renderTabs = [
       { name: 'INTERNATIONAL', value: INTERNATIONAL_KEY, component },
@@ -89,10 +88,7 @@ class SupportReceived extends PureComponent {
 
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title={title} infoButton />
-        <ModalInfo title={title}>
-          The financial support committed and received from international sources, as well as domestic funds committed through government grants and loans, are reported below.
-        </ModalInfo>
+        <SectionTitle isSubtitle title={title} description={description} />
         <TabSwitcher
           tabs={renderTabs}
           searchActive={false}
@@ -118,7 +114,8 @@ SupportReceived.propTypes = {
   values: PropTypes.object,
   dropdownConfig: PropTypes.array,
   data: PropTypes.array,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 
 SupportReceived.defaultProps = {

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -58,7 +58,8 @@ class GHGHistoricalEmissions extends PureComponent {
       metricOptions,
       emissionsParams,
       chartData,
-      downloadUri
+      downloadUri,
+      title
     } = this.props;
     const dropdowns = (
       <div className={styles.dropdowWrapper}>
@@ -108,8 +109,8 @@ class GHGHistoricalEmissions extends PureComponent {
     return (
       <React.Fragment>
         <Section theme={styles}>
-          <SectionTitle isSubtitle title="Historical emissions" infoButton />
-          <ModalInfo title="Historical emissions">
+          <SectionTitle isSubtitle title={title} infoButton />
+          <ModalInfo title={title}>
             This section presents a summary of South Africa’s most recent GHG inventory, covering the following emissions sectors: Energy; Industrial Processes and Product Use; Agriculture, Forestry and Other Land Use; and Waste. Full details are reported in South Africa’s 2017 GHG National Inventory Report.
           </ModalInfo>
           <TabletLandscape>
@@ -160,7 +161,8 @@ GHGHistoricalEmissions.propTypes = {
   emissionsParams: PropTypes.object,
   onFilterChange: PropTypes.func.isRequired,
   updateFiltersSelected: PropTypes.func.isRequired,
-  downloadUri: PropTypes.string
+  downloadUri: PropTypes.string,
+  title: PropTypes.string.isRequired
 };
 GHGHistoricalEmissions.defaultProps = {
   chartData: {},

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -9,7 +9,6 @@ import MetadataProvider from 'providers/metadata-provider';
 import GHGEmissionsProvider from 'providers/ghg-emissions-provider';
 import WorldBankProvider from 'providers/world-bank-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
-import ModalInfo from 'components/modal-info';
 
 import styles from './historical-styles';
 
@@ -59,7 +58,8 @@ class GHGHistoricalEmissions extends PureComponent {
       emissionsParams,
       chartData,
       downloadUri,
-      title
+      title,
+      description
     } = this.props;
     const dropdowns = (
       <div className={styles.dropdowWrapper}>
@@ -109,10 +109,7 @@ class GHGHistoricalEmissions extends PureComponent {
     return (
       <React.Fragment>
         <Section theme={styles}>
-          <SectionTitle isSubtitle title={title} infoButton />
-          <ModalInfo title={title}>
-            This section presents a summary of South Africa’s most recent GHG inventory, covering the following emissions sectors: Energy; Industrial Processes and Product Use; Agriculture, Forestry and Other Land Use; and Waste. Full details are reported in South Africa’s 2017 GHG National Inventory Report.
-          </ModalInfo>
+          <SectionTitle isSubtitle title={title} description={description} />
           <TabletLandscape>
             {matches => {
               if (matches) {
@@ -162,7 +159,8 @@ GHGHistoricalEmissions.propTypes = {
   onFilterChange: PropTypes.func.isRequired,
   updateFiltersSelected: PropTypes.func.isRequired,
   downloadUri: PropTypes.string,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 GHGHistoricalEmissions.defaultProps = {
   chartData: {},

--- a/app/javascript/app/pages/ghg-emissions/inventory/inventory-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/inventory/inventory-component.jsx
@@ -9,7 +9,6 @@ import { Button, Icon } from 'cw-components';
 import DataTable from 'components/data-table';
 import button from 'styles/themes/button';
 import { GHG_NATIONAL_REPORT } from 'constants/links';
-import ModalInfo from 'components/modal-info';
 import styles from './inventory-styles.scss';
 
 class GHGInventory extends PureComponent {
@@ -37,15 +36,12 @@ class GHGInventory extends PureComponent {
   }
 
   render() {
-    const { searchFilter, activeTabValue, title } = this.props;
+    const { searchFilter, activeTabValue, title, description } = this.props;
     return (
       <div className={styles.row}>
         <div className="layout-container">
           <div className={styles.titleContainer}>
-            <SectionTitle isSubtitle title={title} infoButton />
-            <ModalInfo title={title}>
-              South Africa strives to continuously improve its national GHG inventory through the National Greenhouse Gas Improvement Programmes,  a series of sector-specific projects that target improvements in activity data collection, country-specific methodologies and emission factors used.
-            </ModalInfo>
+            <SectionTitle isSubtitle title={title} noMarginBottom />
             <div className={styles.actionContainer}>
               <div className={styles.downloadDescription}>
                 Download a full Inventory Report
@@ -59,6 +55,10 @@ class GHGInventory extends PureComponent {
               </Button>
             </div>
           </div>
+          <p
+            className={styles.sectionDescription}
+            dangerouslySetInnerHTML={{ __html: description }}
+          />
         </div>
         <TabSwitcher
           tabs={this.renderTabs()}
@@ -84,7 +84,8 @@ GHGInventory.propTypes = {
   }),
   activeTabValue: PropTypes.string,
   updateQueryParam: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 
 GHGInventory.defaultProps = {

--- a/app/javascript/app/pages/ghg-emissions/inventory/inventory-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/inventory/inventory-component.jsx
@@ -37,17 +37,13 @@ class GHGInventory extends PureComponent {
   }
 
   render() {
-    const { searchFilter, activeTabValue } = this.props;
+    const { searchFilter, activeTabValue, title } = this.props;
     return (
       <div className={styles.row}>
         <div className="layout-container">
           <div className={styles.titleContainer}>
-            <SectionTitle
-              isSubtitle
-              title="GHG Inventory Improvement Programmes"
-              infoButton
-            />
-            <ModalInfo title="GHG Inventory Improvement Programmes">
+            <SectionTitle isSubtitle title={title} infoButton />
+            <ModalInfo title={title}>
               South Africa strives to continuously improve its national GHG inventory through the National Greenhouse Gas Improvement Programmes,  a series of sector-specific projects that target improvements in activity data collection, country-specific methodologies and emission factors used.
             </ModalInfo>
             <div className={styles.actionContainer}>
@@ -87,7 +83,8 @@ GHGInventory.propTypes = {
     ellipsisColumns: PropTypes.array
   }),
   activeTabValue: PropTypes.string,
-  updateQueryParam: PropTypes.func.isRequired
+  updateQueryParam: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired
 };
 
 GHGInventory.defaultProps = {

--- a/app/javascript/app/pages/ghg-emissions/inventory/inventory-styles.scss
+++ b/app/javascript/app/pages/ghg-emissions/inventory/inventory-styles.scss
@@ -39,3 +39,11 @@
     }
   }
 }
+
+.sectionDescription {
+  font-size: $font-size;
+  color: $midnightblue;
+  line-height: 1.38;
+  margin-bottom: 20px;
+  padding-bottom: $gutter-padding;
+}

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
@@ -110,17 +110,17 @@ class ProjectedEmissions extends PureComponent {
   };
 
   render() {
-    const { chartData } = this.props;
+    const { chartData, title } = this.props;
     return (
       <div className={styles.grid}>
         <div className={styles.toolbarWithSectionTitle}>
           <SectionTitle
             isSubtitle
-            title="Projected Emissions"
+            title={title}
             theme={{ sectionTitle: styles.title, iconContainer: styles.icon }}
             infoButton
           />
-          <ModalInfo title="Projected Emissions">
+          <ModalInfo title={title}>
             This section shows tracking of South Africa’s GHG emissions reductions against different scenarios, including Business as Usual (BaU), Peak-Plateau-Decline (PPD), and long-term mitigation scenarios.
           </ModalInfo>
           <InfoDownloadToolbox
@@ -153,7 +153,8 @@ class ProjectedEmissions extends PureComponent {
 }
 ProjectedEmissions.propTypes = {
   onFilterChange: PropTypes.func.isRequired,
-  chartData: PropTypes.object
+  chartData: PropTypes.object,
+  title: PropTypes.string.isRequired
 };
 ProjectedEmissions.defaultProps = { chartData: {} };
 export default ProjectedEmissions;

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
@@ -10,7 +10,6 @@ import InfoDownloadToolbox from 'components/info-download-toolbox';
 
 import { Area, Line } from 'recharts';
 import isUndefined from 'lodash/isUndefined';
-import ModalInfo from 'components/modal-info';
 
 import styles from './projected-emissions-styles.scss';
 
@@ -110,7 +109,7 @@ class ProjectedEmissions extends PureComponent {
   };
 
   render() {
-    const { chartData, title } = this.props;
+    const { chartData, title, description } = this.props;
     return (
       <div className={styles.grid}>
         <div className={styles.toolbarWithSectionTitle}>
@@ -118,16 +117,17 @@ class ProjectedEmissions extends PureComponent {
             isSubtitle
             title={title}
             theme={{ sectionTitle: styles.title, iconContainer: styles.icon }}
-            infoButton
+            noMarginBottom
           />
-          <ModalInfo title={title}>
-            This section shows tracking of South Africa’s GHG emissions reductions against different scenarios, including Business as Usual (BaU), Peak-Plateau-Decline (PPD), and long-term mitigation scenarios.
-          </ModalInfo>
           <InfoDownloadToolbox
             slugs="DEA2016e"
             downloadUri="ghg/projected_emissions"
           />
         </div>
+        <p
+          className={styles.sectionDescription}
+          dangerouslySetInnerHTML={{ __html: description }}
+        />
         {
           chartData && chartData.config && (
           <Chart
@@ -154,7 +154,8 @@ class ProjectedEmissions extends PureComponent {
 ProjectedEmissions.propTypes = {
   onFilterChange: PropTypes.func.isRequired,
   chartData: PropTypes.object,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 ProjectedEmissions.defaultProps = { chartData: {} };
 export default ProjectedEmissions;

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-styles.scss
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-styles.scss
@@ -24,3 +24,11 @@
   margin-bottom: $gutter-padding;
   margin-top: $gutter-padding * 2;
 }
+
+.sectionDescription {
+  font-size: $font-size;
+  color: $midnightblue;
+  line-height: 1.38;
+  margin-bottom: 20px;
+  padding-bottom: $gutter-padding;
+}

--- a/app/javascript/app/pages/home/home-component.jsx
+++ b/app/javascript/app/pages/home/home-component.jsx
@@ -1,41 +1,39 @@
 import React, { PureComponent } from 'react';
+import { PropTypes } from 'prop-types';
 import { Section } from 'cw-components';
 import background from 'assets/hero';
 import NDCPledge from 'components/home/ndc-pledge';
 import TotalGHGEmissions from 'components/home/total-ghg-emissions';
 import HomeFlagshipProgrammes from 'components/home/flagship-programmes';
+import SectionsContentProvider from 'providers/sections-content-provider';
 
 import styles from './home-styles.scss';
 
 class Home extends PureComponent {
   render() {
+    const { introText } = this.props;
+
     return (
       <div className={styles.page}>
         <Section backgroundImage={background} theme={styles}>
           <div className={styles.verticalCenterText}>
             <div className={styles.introTextContainer}>
-              <p className={styles.introText}>
-                The{' '}
-                <span className={styles.bold}>
-                  South Africa’s Biennial Update Report
-                </span>
-                {' '}
-                offers open data, visualizations and analysis to help you gather insights on South Africa’s climate progress.
-                It is an an important part of the National Climate Change
-                Monitoring and Evaluation (M&E) System established as part of
-                the national efforts to track South Africa
-                {'’'}
-                s overall transition
-                to a low carbon and climate resilient society and economy.
-              </p>
+              <p
+                className={styles.introText}
+                dangerouslySetInnerHTML={{ __html: introText }}
+              />
             </div>
           </div>
         </Section>
         <NDCPledge />
         <TotalGHGEmissions />
         <HomeFlagshipProgrammes />
+        <SectionsContentProvider />
       </div>
     );
   }
 }
+
+Home.propTypes = { introText: PropTypes.string.isRequired };
+
 export default Home;

--- a/app/javascript/app/pages/home/home.js
+++ b/app/javascript/app/pages/home/home.js
@@ -1,3 +1,9 @@
+import { connect } from 'react-redux';
 import HomeComponent from './home-component';
 
-export default HomeComponent;
+const mapStateToProps = ({ SectionsContent }) => {
+  const { data } = SectionsContent;
+  return { introText: data && data.intro && data.intro.description };
+};
+
+export default connect(mapStateToProps, null)(HomeComponent);

--- a/app/javascript/app/pages/mitigation/flagship-programmes/flagship-programmes-component.jsx
+++ b/app/javascript/app/pages/mitigation/flagship-programmes/flagship-programmes-component.jsx
@@ -1,16 +1,20 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import FlagshipProgrammesInfo from './flagship-programmes-info';
 import PrioritisedFlagshipProgrammes from './prioritised-flagship-programmes';
 
 class FlagshipProgrammes extends PureComponent {
   render() {
+    const { title } = this.props;
     return (
       <div>
-        <FlagshipProgrammesInfo />
+        <FlagshipProgrammesInfo title={title} />
         <PrioritisedFlagshipProgrammes />
       </div>
     );
   }
 }
+
+FlagshipProgrammes.propTypes = { title: PropTypes.string.isRequired };
 
 export default FlagshipProgrammes;

--- a/app/javascript/app/pages/mitigation/flagship-programmes/flagship-programmes-info/flagship-programmes-info-component.jsx
+++ b/app/javascript/app/pages/mitigation/flagship-programmes/flagship-programmes-info/flagship-programmes-info-component.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import SectionTitle from 'components/section-title';
 import flagshipLogo from 'assets/flagship-logo.png';
 import flagshipLogoRetina from 'assets/flagship-logo@2x.png';
@@ -22,15 +23,12 @@ class FlagshipProgrammesInfo extends PureComponent {
       'Waste management',
       'Water conservation and water demand management'
     ];
+    const { title } = this.props;
     return (
       <div className={styles.flagshipProgrammes}>
         <div className={styles.generalInfoContainer}>
           <div className={styles.generalInfo}>
-            <SectionTitle
-              isSubtitle
-              title="Flagship Programmes"
-              className={styles.title}
-            />
+            <SectionTitle isSubtitle title={title} className={styles.title} />
             <p>
               <span className={styles.bold}>
                 South Africa already has a well-developed base for mitigating climate change and building climate resilience,
@@ -99,4 +97,5 @@ class FlagshipProgrammesInfo extends PureComponent {
     );
   }
 }
+FlagshipProgrammesInfo.propTypes = { title: PropTypes.string.isRequired };
 export default FlagshipProgrammesInfo;

--- a/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-component.jsx
@@ -43,11 +43,11 @@ class MitigationActions extends PureComponent {
   }
 
   render() {
-    const { searchFilter, activeTabValue } = this.props;
+    const { searchFilter, activeTabValue, title } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title="Mitigation Actions" infoButton />
-        <ModalInfo title="Mitigation actions">
+        <SectionTitle isSubtitle title={title} infoButton />
+        <ModalInfo title={title}>
           <p>
             South Africa’s national government will implement a mix of policies and measures over five-year periods. The 2016 and 2020 phase will focus demonstrating policies to meet South Africa’s Cancun pledge. The 2021-2025 and 2026-2030 phases will focus on achieving the pledges made in South Africa’s NDC.
           </p>
@@ -81,7 +81,8 @@ MitigationActions.propTypes = {
     ellipsisColumns: PropTypes.array
   }),
   activeTabValue: PropTypes.string,
-  updateQueryParam: PropTypes.func.isRequired
+  updateQueryParam: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired
 };
 MitigationActions.defaultProps = {
   searchFilter: '',

--- a/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-component.jsx
@@ -4,7 +4,6 @@ import SectionTitle from 'components/section-title';
 import TabSwitcher from 'components/tab-switcher';
 import MitigationActionsProvider from 'providers/mitigation-actions-provider';
 import DataTable from 'components/data-table';
-import ModalInfo from 'components/modal-info';
 import styles from './mitigation-actions-styles.scss';
 
 const ALL_ACTIONS_KEY = 'allActions';
@@ -43,21 +42,10 @@ class MitigationActions extends PureComponent {
   }
 
   render() {
-    const { searchFilter, activeTabValue, title } = this.props;
+    const { searchFilter, activeTabValue, title, description } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title={title} infoButton />
-        <ModalInfo title={title}>
-          <p>
-            South Africa’s national government will implement a mix of policies and measures over five-year periods. The 2016 and 2020 phase will focus demonstrating policies to meet South Africa’s Cancun pledge. The 2021-2025 and 2026-2030 phases will focus on achieving the pledges made in South Africa’s NDC.
-          </p>
-          <p>
-            Policy instruments to aid in achieving this are under development and include a carbon tax, sectoral emission targets (SETs) for sectors, company-level carbon budgets, regulatory standards and controls for specifically identified GHG pollutants and emitters, and continued implementation of the Climate Change Flagship Programmes.
-          </p>
-          <p>
-            Key mitigation actions being implemented by national, provincial and municipal level governments, the, private sector and non-profit organisations in South Africa are discussed below.
-          </p>
-        </ModalInfo>
+        <SectionTitle isSubtitle title={title} description={description} />
         <TabSwitcher
           tabs={this.renderTabs()}
           searchFilter={searchFilter}
@@ -82,7 +70,8 @@ MitigationActions.propTypes = {
   }),
   activeTabValue: PropTypes.string,
   updateQueryParam: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 MitigationActions.defaultProps = {
   searchFilter: '',

--- a/app/javascript/app/pages/mitigation/mitigation-effects/mitigation-effects-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-effects/mitigation-effects-component.jsx
@@ -30,11 +30,11 @@ class MitigationEffects extends PureComponent {
   }
 
   render() {
-    const { activeTabValue } = this.props;
+    const { activeTabValue, title } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title="Mitigation Effects" infoButton />
-        <ModalInfo title="Mitigation Effects">
+        <SectionTitle isSubtitle title={title} infoButton />
+        <ModalInfo title={title}>
           Through the National Climate Change Response Monitoring and Evaluation System (M&E System), South Africa is continuously striving to quantify the effects of mitigation policies, strategies and actions. This section presents the mitigation actions for which mitigation effects and sustainable development co-benefits have been quantified.
         </ModalInfo>
         <TabSwitcher
@@ -53,7 +53,8 @@ class MitigationEffects extends PureComponent {
 MitigationEffects.propTypes = {
   updateQueryParam: PropTypes.func.isRequired,
   section: PropTypes.string,
-  activeTabValue: PropTypes.string
+  activeTabValue: PropTypes.string,
+  title: PropTypes.string.isRequired
 };
 
 MitigationEffects.defaultProps = {

--- a/app/javascript/app/pages/mitigation/mitigation-effects/mitigation-effects-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-effects/mitigation-effects-component.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import MitigationEffectsProvider from 'providers/mitigation-effects-provider';
 import SectionTitle from 'components/section-title';
 import TabSwitcher from 'components/tab-switcher';
-import ModalInfo from 'components/modal-info';
 import { PropTypes } from 'prop-types';
 import Summary from './summary';
 import styles from './mitigation-effects-styles';
@@ -30,13 +29,10 @@ class MitigationEffects extends PureComponent {
   }
 
   render() {
-    const { activeTabValue, title } = this.props;
+    const { activeTabValue, title, description } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title={title} infoButton />
-        <ModalInfo title={title}>
-          Through the National Climate Change Response Monitoring and Evaluation System (M&E System), South Africa is continuously striving to quantify the effects of mitigation policies, strategies and actions. This section presents the mitigation actions for which mitigation effects and sustainable development co-benefits have been quantified.
-        </ModalInfo>
+        <SectionTitle isSubtitle title={title} description={description} />
         <TabSwitcher
           tabs={this.renderTabs()}
           searchActive={false}
@@ -54,7 +50,8 @@ MitigationEffects.propTypes = {
   updateQueryParam: PropTypes.func.isRequired,
   section: PropTypes.string,
   activeTabValue: PropTypes.string,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 
 MitigationEffects.defaultProps = {

--- a/app/javascript/app/pages/national-circumstances/economy/economy-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/economy/economy-component.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import SectionTitle from 'components/section-title';
 import TabSwitcher from 'components/tab-switcher';
-import ModalInfo from 'components/modal-info';
 import GDP from './gdp';
 import HumanDevelopmentIndex from './human-development-index';
 import GDPGrowth from './gdp-growth';
@@ -35,13 +34,10 @@ class Economy extends PureComponent {
   };
 
   render() {
-    const { title } = this.props;
+    const { title, description } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title={title} infoButton />
-        <ModalInfo title={title}>
-          South Africa is a significant industrial and economic power, with one of the largest economies in Africa.
-        </ModalInfo>
+        <SectionTitle isSubtitle title={title} description={description} />
         <TabSwitcher
           tabs={this.state.tabs}
           actionsActive={false}
@@ -59,7 +55,8 @@ Economy.propTypes = {
   query: PropTypes.object,
   activeTabValue: PropTypes.string,
   updateQueryParam: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 
 Economy.defaultProps = { query: null, activeTabValue: null };

--- a/app/javascript/app/pages/national-circumstances/economy/economy-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/economy/economy-component.jsx
@@ -35,10 +35,11 @@ class Economy extends PureComponent {
   };
 
   render() {
+    const { title } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title="Economy" infoButton />
-        <ModalInfo title="Economy">
+        <SectionTitle isSubtitle title={title} infoButton />
+        <ModalInfo title={title}>
           South Africa is a significant industrial and economic power, with one of the largest economies in Africa.
         </ModalInfo>
         <TabSwitcher
@@ -57,7 +58,8 @@ class Economy extends PureComponent {
 Economy.propTypes = {
   query: PropTypes.object,
   activeTabValue: PropTypes.string,
-  updateQueryParam: PropTypes.func.isRequired
+  updateQueryParam: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired
 };
 
 Economy.defaultProps = { query: null, activeTabValue: null };

--- a/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
@@ -9,7 +9,6 @@ import NationalCircumstancesProvider from 'providers/national-circumstances-prov
 import WorldBankProvider from 'providers/world-bank-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
 import { format } from 'd3-format';
-import ModalInfo from 'components/modal-info';
 
 import styles from './energy-styles';
 
@@ -37,7 +36,8 @@ class Energy extends PureComponent {
       chartTypeSelected,
       chartTypeOptions,
       chartData,
-      title
+      title,
+      description
     } = this.props;
     const dropdowns = (
       <div className={styles.dropdowWrapper}>
@@ -69,10 +69,7 @@ class Energy extends PureComponent {
     return (
       <React.Fragment>
         <Section theme={styles}>
-          <SectionTitle isSubtitle title={title} infoButton />
-          <ModalInfo title={title}>
-            Energy production and mining are the largest sources of GHG emissions in South Africa... The energy intensity of the South African economy has resulted in an emissions profile that differs substantially from that of other developing countries, particularly on the African continent.
-          </ModalInfo>
+          <SectionTitle isSubtitle title={title} description={description} />
           <TabletLandscape>
             {matches => {
               if (matches) {
@@ -120,7 +117,8 @@ Energy.propTypes = {
   emissionsParams: PropTypes.object,
   onFilterChange: PropTypes.func.isRequired,
   updateFiltersSelected: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 
 Energy.defaultProps = {

--- a/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
@@ -36,7 +36,8 @@ class Energy extends PureComponent {
       metricOptions,
       chartTypeSelected,
       chartTypeOptions,
-      chartData
+      chartData,
+      title
     } = this.props;
     const dropdowns = (
       <div className={styles.dropdowWrapper}>
@@ -68,8 +69,8 @@ class Energy extends PureComponent {
     return (
       <React.Fragment>
         <Section theme={styles}>
-          <SectionTitle isSubtitle title="Energy supply" infoButton />
-          <ModalInfo title="Energy supply">
+          <SectionTitle isSubtitle title={title} infoButton />
+          <ModalInfo title={title}>
             Energy production and mining are the largest sources of GHG emissions in South Africa... The energy intensity of the South African economy has resulted in an emissions profile that differs substantially from that of other developing countries, particularly on the African continent.
           </ModalInfo>
           <TabletLandscape>
@@ -118,7 +119,8 @@ Energy.propTypes = {
   metricSelected: PropTypes.object,
   emissionsParams: PropTypes.object,
   onFilterChange: PropTypes.func.isRequired,
-  updateFiltersSelected: PropTypes.func.isRequired
+  updateFiltersSelected: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired
 };
 
 Energy.defaultProps = {

--- a/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-component.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Card } from 'cw-components';
 import SectionTitle from 'components/section-title';
 import NaturalDisastersDataProvider from 'providers/natural-disasters-data-provider';
-import ModalInfo from 'components/modal-info';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
 import styles from './natural-disasters-styles.scss';
 
@@ -13,11 +12,11 @@ function createMarkup(description) {
 
 class NaturalDisasters extends PureComponent {
   render() {
-    const { naturalDisastersData, title } = this.props;
+    const { naturalDisastersData, title, description } = this.props;
     return (
       <div className={styles.sectionWrapper}>
         <div className={styles.titleContainer}>
-          <SectionTitle isSubtitle title={title} infoButton />
+          <SectionTitle isSubtitle title={title} />
           <div className={styles.buttonWrapper}>
             <InfoDownloadToolbox
               slugs="COGTA2015"
@@ -25,9 +24,10 @@ class NaturalDisasters extends PureComponent {
             />
           </div>
         </div>
-        <ModalInfo title={title}>
-          South Africa is exposed to natural disasters including drought, floods and wildfires. Economic losses from weather-related disasters have increased in recent years.
-        </ModalInfo>
+        <p
+          className={styles.sectionDescription}
+          dangerouslySetInnerHTML={{ __html: description }}
+        />
         <div className={styles.cardsContainer}>
           {
             naturalDisastersData && naturalDisastersData.map(card => (
@@ -50,7 +50,8 @@ class NaturalDisasters extends PureComponent {
 
 NaturalDisasters.propTypes = {
   naturalDisastersData: PropTypes.array,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 NaturalDisasters.defaultProps = { naturalDisastersData: [] };
 

--- a/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-component.jsx
@@ -13,11 +13,11 @@ function createMarkup(description) {
 
 class NaturalDisasters extends PureComponent {
   render() {
-    const { naturalDisastersData } = this.props;
+    const { naturalDisastersData, title } = this.props;
     return (
       <div className={styles.sectionWrapper}>
         <div className={styles.titleContainer}>
-          <SectionTitle isSubtitle title="Natural Disasters" infoButton />
+          <SectionTitle isSubtitle title={title} infoButton />
           <div className={styles.buttonWrapper}>
             <InfoDownloadToolbox
               slugs="COGTA2015"
@@ -25,7 +25,7 @@ class NaturalDisasters extends PureComponent {
             />
           </div>
         </div>
-        <ModalInfo title="Natural Disasters">
+        <ModalInfo title={title}>
           South Africa is exposed to natural disasters including drought, floods and wildfires. Economic losses from weather-related disasters have increased in recent years.
         </ModalInfo>
         <div className={styles.cardsContainer}>
@@ -48,7 +48,10 @@ class NaturalDisasters extends PureComponent {
   }
 }
 
-NaturalDisasters.propTypes = { naturalDisastersData: PropTypes.array };
+NaturalDisasters.propTypes = {
+  naturalDisastersData: PropTypes.array,
+  title: PropTypes.string.isRequired
+};
 NaturalDisasters.defaultProps = { naturalDisastersData: [] };
 
 export default NaturalDisasters;

--- a/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-styles.scss
+++ b/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-styles.scss
@@ -64,3 +64,11 @@
     padding-top: 55px;
   }
 }
+
+.sectionDescription {
+  font-size: $font-size;
+  color: $midnightblue;
+  line-height: 1.38;
+  margin-bottom: 20px;
+  padding-bottom: $gutter-padding;
+}

--- a/app/javascript/app/pages/national-circumstances/population/population-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/population/population-component.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import SectionTitle from 'components/section-title';
 import TabSwitcher from 'components/tab-switcher';
 import NationalCircumstancesProvider from 'providers/national-circumstances-provider';
-import ModalInfo from 'components/modal-info';
 import PopulationTab from './population-tab';
 import DistributionByAge from './distribution-by-age';
 
@@ -56,13 +55,10 @@ class Population extends PureComponent {
   }
 
   render() {
-    const { activeTabValue, title } = this.props;
+    const { activeTabValue, title, description } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title={title} infoButton />
-        <ModalInfo title={title}>
-          South Africa’s population is estimated at 54 million people. The estimated population growth rate has steadily increased from approximately 1.27% from 2002–2003 to 1.58% from 2013–2014.
-        </ModalInfo>
+        <SectionTitle isSubtitle title={title} description={description} />
         <TabSwitcher
           tabs={this.renderTabs()}
           actionsActive={false}
@@ -84,7 +80,8 @@ Population.propTypes = {
   updateQueryParam: PropTypes.func.isRequired,
   yearsOptions: PropTypes.array,
   yearSelected: PropTypes.object,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 Population.defaultProps = {
   query: null,

--- a/app/javascript/app/pages/national-circumstances/population/population-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/population/population-component.jsx
@@ -56,11 +56,11 @@ class Population extends PureComponent {
   }
 
   render() {
-    const { activeTabValue } = this.props;
+    const { activeTabValue, title } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title="Population" infoButton />
-        <ModalInfo title="Population">
+        <SectionTitle isSubtitle title={title} infoButton />
+        <ModalInfo title={title}>
           South Africa’s population is estimated at 54 million people. The estimated population growth rate has steadily increased from approximately 1.27% from 2002–2003 to 1.58% from 2013–2014.
         </ModalInfo>
         <TabSwitcher
@@ -83,7 +83,8 @@ Population.propTypes = {
   activeTabValue: PropTypes.string,
   updateQueryParam: PropTypes.func.isRequired,
   yearsOptions: PropTypes.array,
-  yearSelected: PropTypes.object
+  yearSelected: PropTypes.object,
+  title: PropTypes.string.isRequired
 };
 Population.defaultProps = {
   query: null,

--- a/app/javascript/app/pages/national-circumstances/provincial/provincial-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/provincial/provincial-component.jsx
@@ -29,15 +29,11 @@ class Provincial extends PureComponent {
   }
 
   render() {
-    const { activeTabValue } = this.props;
+    const { activeTabValue, title } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle
-          isSubtitle
-          title="Provincial Development Priorities"
-          infoButton
-        />
-        <ModalInfo title="Provincial Development Priorities">
+        <SectionTitle isSubtitle title={title} infoButton />
+        <ModalInfo title={title}>
           Scroll over each of South Africa’s nine provinces to see how they are addressing climate change in their provincial climate change response priorities.
         </ModalInfo>
         <TabSwitcher
@@ -58,7 +54,8 @@ Provincial.propTypes = {
   query: PropTypes.object,
   selectedData: PropTypes.object,
   activeTabValue: PropTypes.string,
-  updateQueryParam: PropTypes.func.isRequired
+  updateQueryParam: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired
 };
 Provincial.defaultProps = {
   query: null,

--- a/app/javascript/app/pages/national-circumstances/provincial/provincial-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/provincial/provincial-component.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import SectionTitle from 'components/section-title';
 import TabSwitcher from 'components/tab-switcher';
 import NationalCircumstancesPrioritiesProvider from 'providers/national-circumstances-priorities-provider';
-import ModalInfo from 'components/modal-info';
 
 import ProvincialContent from './provincial-development-priorities-content';
 import styles from './provincial-styles.scss';
@@ -29,13 +28,10 @@ class Provincial extends PureComponent {
   }
 
   render() {
-    const { activeTabValue, title } = this.props;
+    const { activeTabValue, title, description } = this.props;
     return (
       <div className={styles.row}>
-        <SectionTitle isSubtitle title={title} infoButton />
-        <ModalInfo title={title}>
-          Scroll over each of South Africa’s nine provinces to see how they are addressing climate change in their provincial climate change response priorities.
-        </ModalInfo>
+        <SectionTitle isSubtitle title={title} description={description} />
         <TabSwitcher
           tabs={this.renderTabs()}
           searchActive={false}
@@ -55,7 +51,8 @@ Provincial.propTypes = {
   selectedData: PropTypes.object,
   activeTabValue: PropTypes.string,
   updateQueryParam: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired
 };
 Provincial.defaultProps = {
   query: null,

--- a/app/javascript/app/providers/sections-content-provider/sections-content-provider-actions.js
+++ b/app/javascript/app/providers/sections-content-provider/sections-content-provider-actions.js
@@ -1,0 +1,49 @@
+import { createAction, createThunkAction } from 'redux-tools';
+import { SAAPI } from 'services/api';
+
+import isEmpty from 'lodash/isEmpty';
+
+export const fetchSectionsContentInit = createAction(
+  'fetchSectionsContentInit'
+);
+export const fetchSectionsContentReady = createAction(
+  'fetchSectionsContentReady'
+);
+export const fetchSectionsContentFail = createAction(
+  'fetchSectionsContentFail'
+);
+
+export const fetchSectionsContent = createThunkAction(
+  'fetchSectionsContent',
+  () => (dispatch, state) => {
+    const { SectionsContent } = state();
+    if (
+      SectionsContent &&
+        isEmpty(SectionsContent.data) &&
+        !SectionsContent.loading
+    ) {
+      dispatch(fetchSectionsContentInit());
+      SAAPI
+        .get('section_content')
+        .then(response => {
+          if (response && response.data) {
+            const { data } = response;
+            const sectionsContentMapped = {};
+            data.forEach(section => {
+              sectionsContentMapped[section.name] = {
+                title: section.title,
+                description: section.description
+              };
+            });
+            dispatch(fetchSectionsContentReady({ sectionsContentMapped }));
+          } else {
+            dispatch(fetchSectionsContentReady({}));
+          }
+        })
+        .catch(error => {
+          console.warn(error);
+          dispatch(fetchSectionsContentFail(error && error.message));
+        });
+    }
+  }
+);

--- a/app/javascript/app/providers/sections-content-provider/sections-content-provider-actions.js
+++ b/app/javascript/app/providers/sections-content-provider/sections-content-provider-actions.js
@@ -30,7 +30,7 @@ export const fetchSectionsContent = createThunkAction(
             const { data } = response;
             const sectionsContentMapped = {};
             data.forEach(section => {
-              sectionsContentMapped[section.name] = {
+              sectionsContentMapped[section.slug] = {
                 title: section.title,
                 description: section.description
               };

--- a/app/javascript/app/providers/sections-content-provider/sections-content-provider-reducers.js
+++ b/app/javascript/app/providers/sections-content-provider/sections-content-provider-reducers.js
@@ -1,0 +1,26 @@
+import * as actions from './sections-content-provider-actions';
+
+export const initialState = {
+  loading: false,
+  loaded: false,
+  data: {},
+  error: false
+};
+
+export default {
+  [actions.fetchSectionsContentInit]: state => ({ ...state, loading: true }),
+  [actions.fetchSectionsContentReady]: (
+    state,
+    { payload: { sectionsContentMapped } }
+  ) => ({
+    ...state,
+    loading: false,
+    loaded: true,
+    data: sectionsContentMapped
+  }),
+  [actions.fetchSectionsContentFail]: (state, { payload }) => ({
+    ...state,
+    loading: false,
+    error: payload
+  })
+};

--- a/app/javascript/app/providers/sections-content-provider/sections-content-provider.js
+++ b/app/javascript/app/providers/sections-content-provider/sections-content-provider.js
@@ -1,0 +1,24 @@
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import * as actions from './sections-content-provider-actions';
+import reducers, { initialState } from './sections-content-provider-reducers';
+
+class SectionsContentProvider extends PureComponent {
+  componentDidMount() {
+    const { fetchSectionsContent } = this.props;
+    fetchSectionsContent();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+SectionsContentProvider.propTypes = {
+  fetchSectionsContent: PropTypes.func.isRequired
+};
+
+export const reduxModule = { actions, reducers, initialState };
+export default connect(null, actions)(SectionsContentProvider);

--- a/app/javascript/app/reducers.js
+++ b/app/javascript/app/reducers.js
@@ -40,6 +40,9 @@ import {
 import {
   reduxModule as nationalCircumstancesPriorities
 } from 'providers/national-circumstances-priorities-provider';
+import {
+  reduxModule as sectionsContent
+} from 'providers/sections-content-provider';
 
 // Components
 import { reduxModule as modalMetadata } from 'components/modal-metadata';
@@ -61,7 +64,10 @@ const providersReducers = {
   modalInfo: handleModule(modalInfo),
   projectedEmissions: handleModule(projectedEmissions),
   nationalCircumstances: handleModule(nationalCircumstances),
-  nationalCircumstancesPriorities: handleModule(nationalCircumstancesPriorities)
+  nationalCircumstancesPriorities: handleModule(
+    nationalCircumstancesPriorities
+  ),
+  SectionsContent: handleModule(sectionsContent)
 };
 
 export default combineReducers({

--- a/app/javascript/app/router/router.js
+++ b/app/javascript/app/router/router.js
@@ -29,29 +29,29 @@ export const routes = {
   [NATIONAL_CIRCUMSTANCES]: {
     nav: true,
     label: 'National Circumstances',
+    parentSection: 'national_circumstances',
     link: '/national-circumstances',
     path: '/national-circumstances/:section?',
     component: 'layouts/sections/sections',
-    sections: NationalSections,
-    description: 'This section provides context for South Africa’s climate change response, including information on provincial development priorities, population, economy, energy, and climate risks from natural disasters.'
+    sections: NationalSections
   },
   [GHG_EMISSIONS]: {
     nav: true,
-    label: 'GHG Emissions',
+    label: 'Ghg Emissions',
+    parentSection: 'ghg_emissions',
     link: '/ghg-emissions',
     path: '/ghg-emissions/:section?',
     component: 'layouts/sections/sections',
-    sections: GHGSections,
-    description: 'This section provides information on South Africa’s GHG inventory, the programmes it’s implementing to improve the quality of future national GHG inventories and possible future emissions pathways under different mitigation scenarios.'
+    sections: GHGSections
   },
   [MITIGATIONS]: {
     nav: true,
     label: 'Mitigation Actions',
+    parentSection: 'mitigation_actions_section',
     link: '/mitigation',
     path: '/mitigation/:section?',
     component: 'layouts/sections/sections',
-    sections: MitigationSections,
-    description: `South Africa’s approach to mitigation is informed by its contribution to the international effort to reduce global GHG emissions and its successful management of development and poverty eradication challenges. South Africa is committed to addressing climate change based on science and equity and to work with others to ensure global average temperature increases are kept well below 2°C and potentially 1.5°C above pre-industrial levels. Global average temperature increase of 2°C translates to up to 4°C for South Africa by the end of the century. South Africa’s mitigation action will be accessed against its commitment to reduce emissions to a range between 398 and 614 CO2-eq by 2030 and 2050, as defined in national policy.`
+    sections: MitigationSections
   },
   [FLAGSHIP_DETAIL]: {
     link: '/mitigation/flagship-programmes-detail',
@@ -62,11 +62,11 @@ export const routes = {
   [FINANCIAL_RESOURCES]: {
     nav: true,
     label: 'Financial Resources',
+    parentSection: 'financial_resources',
     link: '/financial-resources',
     path: '/financial-resources/:section?',
     component: 'layouts/sections/sections',
-    sections: FinancialSections,
-    description: 'This section shows climate finance provided from multilateral, bilateral, and domestic sources as well as remaining financial and non-financial support needs.'
+    sections: FinancialSections
   },
   [NOT_FOUND]: {
     path: '/404',

--- a/app/models/section_content.rb
+++ b/app/models/section_content.rb
@@ -1,7 +1,7 @@
 class SectionContent < ApplicationRecord
   belongs_to :parent_section, class_name: 'SectionContent',
-                              foreign_key: 'parent_section_id', optional: true
-  has_many :subsections, class_name: 'SectionContent', foreign_key: 'subsection_id'
+                              foreign_key: 'parent_section_id', optional: true, dependent: :destroy
+  has_many :subsections, class_name: 'SectionContent', foreign_key: 'subsection_id', dependent: :destroy
 
   accepts_nested_attributes_for :subsections, allow_destroy: false
 end

--- a/app/serializers/api/v1/section_content_serializer.rb
+++ b/app/serializers/api/v1/section_content_serializer.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class SectionContentSerializer < ApplicationSerializer
-      attributes :name, :title, :description, :subsections
+      attributes :slug, :title, :description
     end
   end
 end

--- a/config/initial_sections_content.yml
+++ b/config/initial_sections_content.yml
@@ -1,64 +1,64 @@
 sections:
-  - name: intro
+  - slug: intro
     title:
     description: The <b>South Africa’s Biennial Update Report</b> offers open data, visualizations and analysis to help you gather insights on South Africa’s climate progress. It is an an important part of the National Climate Change Monitoring and Evaluation (M&E) System established as part of the national efforts to track South Africa’s overall transition to a low carbon and climate resilient society and economy.
-  - name: ndc_submission
+  - slug: ndc_submission
     title: South Africa National Determined Contribution (NDC) pledge and ambition
     description: Under South Africa’s NDC, GHG emissions will peak between 2020 and 2025, plateau for approximately a decade, landing in the range of 398-614 MtCO2eq as defined by national policy, and decline in absolute terms thereafter.<br><br>The adaptation component of South Africa’s NDC will address adaptation through six goals, underpinned by key elements of adaptation planning, pricing of adaptation investment requirements, equity, and means of implementation.
-  - name: historical_emissions
+  - slug: historical_emissions
     title: Historical Emissions
     description: "South Africa’s National GHG inventory for the period 2000-2014 was compiled according to the IPCC-2006 guidelines and covers four emission sectors: Energy; Industrial Processes and Product Use; Agriculture, Forestry and Other Land Use; and Waste."
-  - name: flagship_programmes
+  - slug: flagship_programmes
     title: Flagship Programmes
     description: The Climate Change Flagship Programmes are strategic measures implemented by the South African government to trigger a large-scale transition to a low-carbon economy and create a more climate-resilient South Africa. They signal climate change investment priorities and provide the certainty needed to stimulate further investment.
-  - name: national_circumstances
+  - slug: national_circumstances
     title: National Circumstances
     description: This section provides context for South Africa’s climate change response, including information on provincial development priorities, population, economy, energy, and climate risks from natural disasters.
-  - name: provincial
+  - slug: provincial
     title: Provincial Development Priorities
-    description:
-  - name: population
+    description: Scroll over each of South Africa’s nine provinces to see how they are addressing climate change in their provincial climate change response priorities.
+  - slug: population
     title: Population
-    description:
-  - name: economy
+    description: South Africa’s population is estimated at 54 million people. The estimated population growth rate has steadily increased from approximately 1.27% from 2002–2003 to 1.58% from 2013–2014.
+  - slug: economy
     title: Economy
-    description:
-  - name: energy
+    description: South Africa is a significant industrial and economic power, with one of the largest economies in Africa.
+  - slug: energy
     title: Energy supply
-    description:
-  - name: natural-disasters
+    description: Energy production and mining are the largest sources of GHG emissions in South Africa... The energy intensity of the South African economy has resulted in an emissions profile that differs substantially from that of other developing countries, particularly on the African continent.
+  - slug: natural-disasters
     title: Natural Disasters
-    description:
-  - name: ghg_emissions
+    description: South Africa is exposed to natural disasters including drought, floods and wildfires. Economic losses from weather-related disasters have increased in recent years.
+  - slug: ghg_emissions
     title: GHG Emissions
     description: This section provides information on South Africa’s GHG inventory, the programmes it’s implementing to improve the quality of future national GHG inventories and possible future emissions pathways under different mitigation scenarios.
-  - name: historical
+  - slug: historical
     title: Historical emissions
-    description:
-  - name: inventory
+    description: "This section presents a summary of South Africa’s most recent GHG inventory, covering the following emissions sectors: Energy; Industrial Processes and Product Use; Agriculture, Forestry and Other Land Use; and Waste. Full details are reported in South Africa’s 2017 GHG National Inventory Report."
+  - slug: inventory
     title: GHG Inventory Improvement Programmes
-    description:
-  - name: projected-emissions
+    description: South Africa strives to continuously improve its national GHG inventory through the National Greenhouse Gas Improvement Programmes, a series of sector-specific projects that target improvements in activity data collection, country-specific methodologies and emission factors used.
+  - slug: projected-emissions
     title: Projected Emissions
-    description:
-  - name: mitigation_actions_section
+    description: This section shows tracking of South Africa’s GHG emissions reductions against different scenarios, including Business as Usual (BaU), Peak-Plateau-Decline (PPD), and long-term mitigation scenarios.
+  - slug: mitigation_actions_section
     title: Mitigation Actions
     description: South Africa’s approach to mitigation is informed by its contribution to the international effort to reduce global GHG emissions and its successful management of development and poverty eradication challenges. South Africa is committed to addressing climate change based on science and equity and to work with others to ensure global average temperature increases are kept well below 2°C and potentially 1.5°C above pre-industrial levels. Global average temperature increase of 2°C translates to up to 4°C for South Africa by the end of the century. South Africa’s mitigation action will be accessed against its commitment to reduce emissions to a range between 398 and 614 CO2-eq by 2030 and 2050, as defined in national policy.
-  - name: mitigation-actions
+  - slug: mitigation-actions
     title: Mitigation Actions
-    description:
-  - name: mitigation-effects
+    description: South Africa’s national government will implement a mix of policies and measures over five-year periods. The 2016 and 2020 phase will focus demonstrating policies to meet South Africa’s Cancun pledge. The 2021-2025 and 2026-2030 phases will focus on achieving the pledges made in South Africa’s NDC. <br><br>Policy instruments to aid in achieving this are under development and include a carbon tax, sectoral emission targets (SETs) for sectors, company-level carbon budgets, regulatory standards and controls for specifically identified GHG pollutants and emitters, and continued implementation of the Climate Change Flagship Programmes. <br><br>Key mitigation actions being implemented by national, provincial and municipal level governments, the, private sector and non-profit organisations in South Africa are discussed below.
+  - slug: mitigation-effects
     title: Mitigation Effects
-    description:
-  - name: flagship-programmes
+    description: Through the National Climate Change Response Monitoring and Evaluation System (M&E System), South Africa is continuously striving to quantify the effects of mitigation policies, strategies and actions. This section presents the mitigation actions for which mitigation effects and sustainable development co-benefits have been quantified.
+  - slug: flagship-programmes
     title: Flagship Programmes
-    description:
-  - name: financial_resources
+    description: 
+  - slug: financial_resources
     title: Financial Resources
     description: This section shows climate finance provided from multilateral, bilateral, and domestic sources as well as remaining financial and non-financial support needs.
-  - name: support-received
+  - slug: support-received
     title: Support Received
-    description:
-  - name: support-needed
+    description: The financial support committed and received from international sources, as well as domestic funds committed through government grants and loans, are reported below.
+  - slug: support-needed
     title: Support Needed
-    description:
+    description: This section includes a summary of support needed for climate change mitigation and adaptation actions.

--- a/config/initial_sections_content.yml
+++ b/config/initial_sections_content.yml
@@ -1,0 +1,64 @@
+sections:
+  - name: intro
+    title:
+    description: The <b>South Africa’s Biennial Update Report</b> offers open data, visualizations and analysis to help you gather insights on South Africa’s climate progress. It is an an important part of the National Climate Change Monitoring and Evaluation (M&E) System established as part of the national efforts to track South Africa’s overall transition to a low carbon and climate resilient society and economy.
+  - name: ndc_submission
+    title: South Africa National Determined Contribution (NDC) pledge and ambition
+    description: Under South Africa’s NDC, GHG emissions will peak between 2020 and 2025, plateau for approximately a decade, landing in the range of 398-614 MtCO2eq as defined by national policy, and decline in absolute terms thereafter.<br><br>The adaptation component of South Africa’s NDC will address adaptation through six goals, underpinned by key elements of adaptation planning, pricing of adaptation investment requirements, equity, and means of implementation.
+  - name: historical_emissions
+    title: Historical Emissions
+    description: "South Africa’s National GHG inventory for the period 2000-2014 was compiled according to the IPCC-2006 guidelines and covers four emission sectors: Energy; Industrial Processes and Product Use; Agriculture, Forestry and Other Land Use; and Waste."
+  - name: flagship_programmes
+    title: Flagship Programmes
+    description: The Climate Change Flagship Programmes are strategic measures implemented by the South African government to trigger a large-scale transition to a low-carbon economy and create a more climate-resilient South Africa. They signal climate change investment priorities and provide the certainty needed to stimulate further investment.
+  - name: national_circumstances
+    title: National Circumstances
+    description: This section provides context for South Africa’s climate change response, including information on provincial development priorities, population, economy, energy, and climate risks from natural disasters.
+  - name: provincial
+    title: Provincial Development Priorities
+    description:
+  - name: population
+    title: Population
+    description:
+  - name: economy
+    title: Economy
+    description:
+  - name: energy
+    title: Energy supply
+    description:
+  - name: natural-disasters
+    title: Natural Disasters
+    description:
+  - name: ghg_emissions
+    title: GHG Emissions
+    description: This section provides information on South Africa’s GHG inventory, the programmes it’s implementing to improve the quality of future national GHG inventories and possible future emissions pathways under different mitigation scenarios.
+  - name: historical
+    title: Historical emissions
+    description:
+  - name: inventory
+    title: GHG Inventory Improvement Programmes
+    description:
+  - name: projected-emissions
+    title: Projected Emissions
+    description:
+  - name: mitigation_actions_section
+    title: Mitigation Actions
+    description: South Africa’s approach to mitigation is informed by its contribution to the international effort to reduce global GHG emissions and its successful management of development and poverty eradication challenges. South Africa is committed to addressing climate change based on science and equity and to work with others to ensure global average temperature increases are kept well below 2°C and potentially 1.5°C above pre-industrial levels. Global average temperature increase of 2°C translates to up to 4°C for South Africa by the end of the century. South Africa’s mitigation action will be accessed against its commitment to reduce emissions to a range between 398 and 614 CO2-eq by 2030 and 2050, as defined in national policy.
+  - name: mitigation-actions
+    title: Mitigation Actions
+    description:
+  - name: mitigation-effects
+    title: Mitigation Effects
+    description:
+  - name: flagship-programmes
+    title: Flagship Programmes
+    description:
+  - name: financial_resources
+    title: Financial Resources
+    description: This section shows climate finance provided from multilateral, bilateral, and domestic sources as well as remaining financial and non-financial support needs.
+  - name: support-received
+    title: Support Received
+    description:
+  - name: support-needed
+    title: Support Needed
+    description:

--- a/config/sections_content_management.yml
+++ b/config/sections_content_management.yml
@@ -1,27 +1,69 @@
 sections:
-  - name: intro
+  - name: HOMEPAGE
+    slug: intro
+    order: 1
     subsections:
-      - name: ndc_submission
-      - name: historical_emissions
-      - name: flagship_programmes
-  - name: national_circumstances
+      - name: HOMEPAGE_ndc_submission
+        slug: ndc_submission
+        order: 2
+      - name: HOMEPAGE_historical_emissions
+        slug: historical_emissions
+        order: 3
+      - name: HOMEPAGE_flagship_programmes
+        slug: flagship_programmes
+        order: 4
+  - name: NATIONAL_CIRCUMSTANCES
+    slug: national_circumstances
+    order: 5
     subsections: 
-      - name: provincial
-      - name: population
-      - name: economy
-      - name: energy
-      - name: natural-disasters
-  - name: ghg_emissions
+      - name: NATIONAL_CIRCUMSTANCES_provincial
+        slug: provincial
+        order: 6
+      - name: NATIONAL_CIRCUMSTANCES_population
+        slug: population
+        order: 7
+      - name: NATIONAL_CIRCUMSTANCES_economy
+        slug: economy
+        order: 8
+      - name: NATIONAL_CIRCUMSTANCES_energy
+        slug: energy
+        order: 9
+      - name: NATIONAL_CIRCUMSTANCES_natural-disasters
+        slug: natural-disasters
+        order: 10
+  - name: GHG_EMISSIONS
+    slug: ghg_emissions
+    order: 11
     subsections:
-      - name: historical
-      - name: inventory
-      - name: projected-emissions
-  - name: mitigation_actions_section
+      - name: GHG_EMISSIONS_historical
+        slug: historical
+        order: 12
+      - name: GHG_EMISSIONS_inventory
+        slug: inventory
+        order: 13
+      - name: GHG_EMISSIONS_projected-emissions
+        slug: projected-emissions
+        order: 14
+  - name: MITIGATION_ACTIONS
+    slug: mitigation_actions_section
+    order: 15
     subsections:
-      - name: mitigation-actions
-      - name: mitigation-effects
-      - name: flagship-programmes
-  - name: financial_resources
+      - name: MITIGATION_ACTIONS_mitigation-actions
+        slug: mitigation-actions
+        order: 16
+      - name: MITIGATION_ACTIONS_mitigation-effects
+        slug: mitigation-effects
+        order: 17
+      - name: MITIGATION_ACTIONS_flagship-programmes
+        slug: flagship-programmes
+        order: 18
+  - name: FINANCIAL_RESOURCES
+    slug: financial_resources
+    order: 19
     subsections: 
-      - name: support-received
-      - name: support-needed
+      - name: FINANCIAL_RESOURCES_support-received
+        slug: support-received
+        order: 20
+      - name: FINANCIAL_RESOURCES_support-needed
+        slug: support-needed
+        order: 21

--- a/config/sections_content_management.yml
+++ b/config/sections_content_management.yml
@@ -6,22 +6,22 @@ sections:
       - name: flagship_programmes
   - name: national_circumstances
     subsections: 
-      - name: provincial_development_priorities
+      - name: provincial
       - name: population
       - name: economy
       - name: energy
-      - name: natural_disasters
+      - name: natural-disasters
   - name: ghg_emissions
     subsections:
-      - name: historical_emissions
-      - name: ghg_inventory_improvement_programmes
-      - name: projected_emissions
+      - name: historical
+      - name: inventory
+      - name: projected-emissions
   - name: mitigation_actions_section
     subsections:
-      - name: mittigation_actions
-      - name: mitigation_effects
-      - name: flagship_programmes
+      - name: mitigation-actions
+      - name: mitigation-effects
+      - name: flagship-programmes
   - name: financial_resources
     subsections: 
-      - name: support_received
-      - name: support_needed
+      - name: support-received
+      - name: support-needed

--- a/db/migrate/20181108100459_add_slug_and_order_to_section_contents.rb
+++ b/db/migrate/20181108100459_add_slug_and_order_to_section_contents.rb
@@ -1,0 +1,6 @@
+class AddSlugAndOrderToSectionContents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :section_contents, :slug, :string
+    add_column :section_contents, :order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_05_145232) do
+ActiveRecord::Schema.define(version: 2018_11_08_100459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -359,6 +359,8 @@ ActiveRecord::Schema.define(version: 2018_11_05_145232) do
     t.text "description"
     t.integer "subsection_id"
     t.string "name"
+    t.string "slug"
+    t.integer "order"
   end
 
   create_table "sections", force: :cascade do |t|

--- a/lib/tasks/add_content_management_records.rake
+++ b/lib/tasks/add_content_management_records.rake
@@ -5,9 +5,17 @@ namespace :db do
     config = YAML.load_file(file)
 
     config['sections'].each do |section|
-      main_section = SectionContent.create(name: section['name'])
+      main_section = SectionContent.create(
+        name: section['name'],
+        order: section['order'],
+        slug: section['slug']
+      )
       section['subsections'].each do |subsection|
-        main_section.subsections << SectionContent.create(name: subsection['name'])
+        main_section.subsections << SectionContent.create(
+          name: subsection['name'],
+          order: subsection['order'],
+          slug: subsection['slug']
+        )
       end
     end
 

--- a/lib/tasks/add_content_management_records.rake
+++ b/lib/tasks/add_content_management_records.rake
@@ -5,8 +5,6 @@ namespace :db do
     config = YAML.load_file(file)
 
     config['sections'].each do |section|
-      next if SectionContent.find_by(name: section['name'])
-
       main_section = SectionContent.create(name: section['name'])
       section['subsections'].each do |subsection|
         main_section.subsections << SectionContent.create(name: subsection['name'])

--- a/lib/tasks/add_initial_sections_content.rake
+++ b/lib/tasks/add_initial_sections_content.rake
@@ -5,7 +5,7 @@ namespace :db do
     config = YAML.load_file(file)
 
     config['sections'].each do |section|
-      s = SectionContent.find_by(name: section['name'])
+      s = SectionContent.find_by(slug: section['slug'])
       s.update(title: section['title'])
       s.update(description: section['description'])
     end

--- a/lib/tasks/add_initial_sections_content.rake
+++ b/lib/tasks/add_initial_sections_content.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  desc 'Add initial sections content'
+  task add_initial_sections_content: :environment do
+    file = File.join(Rails.root, 'config/initial_sections_content.yml')
+    config = YAML.load_file(file)
+
+    config['sections'].each do |section|
+      s = SectionContent.find_by(name: section['name'])
+      s.update(title: section['title'])
+      s.update(description: section['description'])
+    end
+
+    puts 'Sections seeded!'
+  end
+end


### PR DESCRIPTION
This PR adds some changes to Content Management in Admin panel:
- It shows all the sections on index page (I think it's more straightforward, previous solution could be confusing - it was showing only the main sections and nested ones in another view)
- it changes some section keys to match frontend slugs for easier and dynamic retrieval on FE

![image](https://user-images.githubusercontent.com/6136899/48142995-cce76c80-e2a5-11e8-8059-b02a5de897bc.png)

It also integrates FE with BE (section titles and descriptions are now taken from the API).

To note:
Title and Description are both optional on admin panel; some sections might not have description, like nested sections (i.e. Projected Emissions) so it has only title filled. On the other hand, intro text doesn't have a title, only description.

To test it:
If you have previously created SectionContent records with rake task, clean your db:
`SectionContent.destroy_all` ---> because some section names have changed
and then run:
- `rake db:add_content_management_records` -> creates section keys for admin panel
- `rake db:add_initial_sections_content` -> seeds db with initial titles and descriptions

The same must be done on staging (only once):
- `SectionContent.destroy_all`
- `rake db:add_content_management_records`
- `rake db:add_initial_sections_content`
