### PR TITLE
Updates references to gases as data has been updated!

### DIFF
--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
@@ -12,7 +12,7 @@ import {
 } from 'utils/graphs';
 
 const { COUNTRY_ISO } = process.env;
-const defaults = { gas: 'Total GHG', source: 'DEA2017b', sector: 'Energy' };
+const defaults = { gas: 'ALl GHG', source: 'DEA2017b', sector: 'Energy' };
 const getMetaData = ({ metadata = {} }) =>
   metadata.ghg ? metadata.ghg.data : null;
 const getMetricParam = ({ location }) =>
@@ -144,10 +144,10 @@ export const getChartConfig = createSelector(
   }
 );
 
-export const getChartFilters = createSelector(() => [ { label: 'Total GHG' } ]);
+export const getChartFilters = createSelector(() => [ { label: 'All GHG' } ]);
 
 export const getChartFilterSelected = createSelector(() => [
-  { label: 'Total GHG' }
+  { label: 'All GHG' }
 ]);
 
 const getTitleAndDescription = createSelector(

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
@@ -12,7 +12,7 @@ import {
 } from 'utils/graphs';
 
 const { COUNTRY_ISO } = process.env;
-const defaults = { gas: 'TotalGHG', source: 'DEA2017b', sector: 'Energy' };
+const defaults = { gas: 'Total GHG', source: 'DEA2017b', sector: 'Energy' };
 const getMetaData = ({ metadata = {} }) =>
   metadata.ghg ? metadata.ghg.data : null;
 const getMetricParam = ({ location }) =>
@@ -144,10 +144,10 @@ export const getChartConfig = createSelector(
   }
 );
 
-export const getChartFilters = createSelector(() => [ { label: 'TotalGHG' } ]);
+export const getChartFilters = createSelector(() => [ { label: 'Total GHG' } ]);
 
 export const getChartFilterSelected = createSelector(() => [
-  { label: 'TotalGHG' }
+  { label: 'Total GHG' }
 ]);
 
 const getTitleAndDescription = createSelector(

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import groupBy from 'lodash/groupBy';
+import uniq from 'lodash/uniq';
 import has from 'lodash/has';
 import intersection from 'lodash/intersection';
 import { METRIC_OPTIONS } from 'utils/defaults';
@@ -44,12 +45,6 @@ const getDownloadUri = ({ metadata = {} }) => {
   return id ? `emissions.csv?source=${id}&location=ZAF` : null;
 };
 
-const getGas = createSelector(getMetaData, meta => {
-  if (!meta || !meta.gas) return null;
-  const selected = meta.gas.find(gas => gas.label === defaults.gas);
-  return selected && selected.value || null;
-});
-
 const getSource = createSelector(getMetaData, meta => {
   if (!meta || !meta.dataSource) return null;
   const selected = meta.dataSource.find(
@@ -57,15 +52,6 @@ const getSource = createSelector(getMetaData, meta => {
   );
   return selected && selected.value || null;
 });
-
-export const getEmissionsParams = createSelector([ getSource, getGas ], (
-  source,
-  gas
-) =>
-  {
-    if (!source || !gas) return null;
-    return { location: COUNTRY_ISO, gas, source };
-  });
 
 export const getMetricOptions = createSelector(
   [],
@@ -156,6 +142,14 @@ export const getSubSectorSelected = createSelector(
   }
 );
 
+export const getEmissionsParams = createSelector(
+  [ getSource, getGasSelected ],
+  (source, gas) => {
+    if (!source || !gas) return null;
+    return { location: COUNTRY_ISO, gas: gas.map(g => g.value).join(), source };
+  }
+);
+
 const getCalculationData = createSelector([ getWBData ], data => {
   if (!data || !data.length) return null;
   return groupBy(data, 'year');
@@ -213,28 +207,21 @@ const getDataSelected = createSelector(
     return sectors.concat(subsectors);
   }
 );
+
 export const getChartConfig = createSelector(
-  [
-    getEmissionsData,
-    getSectorSelected,
-    getSubSectorSelected,
-    getGasSelected,
-    getMetricSelected
-  ],
-  (data, sectorSelected, subSectorSelected, gasSelected, metricSelected) => {
+  [ getEmissionsData, getSectorSelected, getMetricSelected ],
+  (data, sectorSelected, metricSelected) => {
     if (!data || !sectorSelected) return null;
-    const sectorSelectedLabels = sectorSelected.map(s => s.label);
-    const subSectorSelectedLabels = subSectorSelected.map(s => s.label);
-    const gasSelectedLabels = gasSelected && gasSelected.map(s => s.label);
-    const allLabels = sectorSelectedLabels.concat(subSectorSelectedLabels);
-    const getYOption = columns =>
-      columns.map(d => ({ label: d.sector, value: getYColumnValue(d.sector) }));
-    const yColumns = data
-      .filter(s => allLabels.includes(s.sector))
-      .filter(s => gasSelectedLabels.includes(s.gas));
-    const yColumnOptions = getYOption(yColumns);
-    const allColumnOptions = getYOption(data);
-    const theme = getThemeConfig(allColumnOptions);
+    const getYOption = sectors =>
+      uniq(sectors).map(s => ({ label: s, value: getYColumnValue(s) }));
+    const yColumnSectors = [];
+    uniq(
+      data.forEach(d => {
+        if (d.emissions.some(y => y.value)) yColumnSectors.push(d.sector);
+      })
+    );
+    const yColumnOptions = getYOption(yColumnSectors);
+    const theme = getThemeConfig(yColumnOptions);
     const tooltip = getTooltipConfig(yColumnOptions);
     let { unit } = DEFAULT_AXES_CONFIG.yLeft;
     if (metricSelected.value === METRIC_OPTIONS.PER_GDP.value) {

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -13,9 +13,9 @@ import {
 } from 'utils/graphs';
 
 const { COUNTRY_ISO } = process.env;
-const defaults = { gas: 'TotalGHG', source: 'DEA2017b' };
+const defaults = { gas: 'Total GHG', source: 'DEA2017b' };
 const excludedSectors = [ 'Total including FOLU', 'Total excluding FOLU' ];
-const excludedGases = [ 'Total GHG' ];
+const excludedGases = [ 'TotalGHG' ];
 
 const getMetaData = ({ metadata = {} }) =>
   metadata.ghg ? metadata.ghg.data : null;

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -13,7 +13,7 @@ import {
 } from 'utils/graphs';
 
 const { COUNTRY_ISO } = process.env;
-const defaults = { gas: 'Total GHG', source: 'DEA2017b' };
+const defaults = { gas: 'All GHG', source: 'DEA2017b' };
 const excludedSectors = [ 'Total including FOLU', 'Total excluding FOLU' ];
 const excludedGases = [ 'TotalGHG' ];
 

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -96,7 +96,10 @@ export const getGasSelected = createSelector([ getGasOptions, getGasParam ], (
 ) =>
   {
     if (!gasOptions) return null;
-    if (!gasSelected) return [ gasOptions.find(g => g.label === defaults.gas) ];
+    if (!gasSelected) {
+      const defaultGas = gasOptions.find(g => g.label === defaults.gas);
+      return defaultGas && [ defaultGas ] || null;
+    }
     const gasParsed = gasSelected.split(',').map(s => parseInt(s, 10));
     return gasOptions.filter(s => gasParsed.indexOf(s.value) > -1);
   });

--- a/app/javascript/app/providers/ghg-emissions-provider/ghg-emissions-provider.js
+++ b/app/javascript/app/providers/ghg-emissions-provider/ghg-emissions-provider.js
@@ -11,6 +11,12 @@ class GHGEmissionsProvider extends PureComponent {
     fetchGHGEmissions(params);
   }
 
+  componentDidUpdate(prevProps) {
+    const { fetchGHGEmissions, params } = this.props;
+    const { params: prevParams } = prevProps;
+    if (prevParams.gas !== params.gas) fetchGHGEmissions(params);
+  }
+
   render() {
     return null;
   }

--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -60,9 +60,7 @@ export const getThemeConfig = (columns, colors = CHART_COLORS) => {
   const theme = {};
   columns.forEach((column, i) => {
     const index = column.index || i;
-    const correctedIndex = index < colors.length
-      ? index
-      : index - colors.length;
+    const correctedIndex = index % colors.length;
     theme[column.value] = {
       stroke: colors[correctedIndex],
       fill: colors[correctedIndex]


### PR DESCRIPTION
We received a new batch of data for the GHG emissions of South Africa. This PR makes some changes to match the new data. For instance they removed "TotalGHG" and added "Total GHG" instead. Then I realised that they barely have any data for "Total GHG", so I changed it to use "All GHG" that has more data in the database and also exists as a gas.

But while doing this I realised that if I change the gas the data doesn't update. There doesn't seem to be any requests to the server if we change that dropdown. And because the initial requests doesn't include all the gases, the data doesn't change. I think we need to make sure that if the Gas is changed that the request is made again. This might mean updating the list of sectors again. (When it was using the Total GHG, there was no data, so no sectors were being shown).

@Bluesmile82 can you pick this up when you have the chance and check the issue with fetching data, please?

Thanks!