### PR TITLE
Add admin's email to the worker logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,11 +58,15 @@ git 'https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git' do
   gem 'climate_watch_engine', '~> 1.3.2'
   gem 'cw_locations', '~> 1.3.1', require: 'locations'
   gem 'cw_historical_emissions', '~> 1.3.2', require: 'historical_emissions'
-  gem 'cw_data_uploader', '~> 0.3.2', require: 'data_uploader'
+  # gem 'cw_data_uploader', '~> 0.3.3', require: 'data_uploader'
+end
+
+git 'https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git', branch: 'fix/add-other-mime-types-for-uploading' do
+  gem 'cw_data_uploader', '~> 0.3.3', require: 'data_uploader'
 end
 
 # for debugging
 # gem 'climate_watch_engine', '~> 1.3.2', path: '../climate-watch-gems'
 # gem 'cw_locations', '~> 1.3.1', require: 'locations', path: '../climate-watch-gems'
 # gem 'cw_historical_emissions', '~> 1.3.2', require: 'historical_emissions', path: '../climate-watch-gems'
-# gem 'cw_data_uploader', '~> 0.3.0', require: 'data_uploader', path: '../climate-watch-gems'
+# gem 'cw_data_uploader', '~> 0.3.3', require: 'data_uploader', path: '../climate-watch-gems'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,9 @@
 GIT
   remote: https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git
-  revision: 29f07c0dad9d793867c49833ce2e0ca44111eb1f
+  revision: 8b847f00bf03ee50bc0fcc1acd19cb9c5d41a371
+  branch: fix/add-other-mime-types-for-uploading
   specs:
-    climate_watch_engine (1.3.2)
-      aws-sdk-s3 (~> 1)
-      rails (~> 5.2.0)
-    cw_data_uploader (0.3.2)
+    cw_data_uploader (0.3.3)
       activeadmin
       aws-sdk-rails (~> 2)
       aws-sdk-s3 (~> 1)
@@ -14,6 +12,14 @@ GIT
       pg
       rubyzip
       sidekiq
+
+GIT
+  remote: https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git
+  revision: 29f07c0dad9d793867c49833ce2e0ca44111eb1f
+  specs:
+    climate_watch_engine (1.3.2)
+      aws-sdk-s3 (~> 1)
+      rails (~> 5.2.0)
     cw_historical_emissions (1.3.2)
       active_model_serializers (~> 0.10.0)
       aws-sdk-s3 (~> 1)
@@ -98,8 +104,8 @@ GEM
       activesupport (>= 3.0.0)
     arel (9.0.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.108.0)
-    aws-sdk-core (3.36.0)
+    aws-partitions (1.112.0)
+    aws-sdk-core (3.38.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -360,7 +366,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   climate_watch_engine (~> 1.3.2)!
-  cw_data_uploader (~> 0.3.2)!
+  cw_data_uploader (~> 0.3.3)!
   cw_historical_emissions (~> 1.3.2)!
   cw_locations (~> 1.3.1)!
   devise

--- a/app/admin/south_africa_platform/financial_resources.rb
+++ b/app/admin/south_africa_platform/financial_resources.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'South Africa Platform Financial Resources' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportFinancialResource')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportFinancialResource', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/south_africa_platform/ghg_emissions.rb
+++ b/app/admin/south_africa_platform/ghg_emissions.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'South Africa Platform Ghg Emissions' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportGhg')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportGhg', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/south_africa_platform/historical_emissions.rb
+++ b/app/admin/south_africa_platform/historical_emissions.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'South Africa Platform Historical Emissions' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportHistoricalEmissions')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportHistoricalEmissions', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/south_africa_platform/inventory_improvement.rb
+++ b/app/admin/south_africa_platform/inventory_improvement.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'South Africa Platform Inventory Improvement' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportInventoryImprovement')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportInventoryImprovement', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/south_africa_platform/metadata.rb
+++ b/app/admin/south_africa_platform/metadata.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'South Africa Platform Metadata' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportDataSource')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportDataSource', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/south_africa_platform/mitigation_actions.rb
+++ b/app/admin/south_africa_platform/mitigation_actions.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'South Africa Platform Mitigation Actions' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportMitigation')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportMitigation', current_admin_user.email)
     end
 
     def section_repository

--- a/app/admin/south_africa_platform/national_circumstances.rb
+++ b/app/admin/south_africa_platform/national_circumstances.rb
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'South Africa Platform National Circumstances' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportNationalCircumstances')
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportNationalCircumstances', current_admin_user.email)
     end
 
     def section_repository

--- a/db/migrate/20181113185654_add_user_email_to_worker_logs.data_uploader.rb
+++ b/db/migrate/20181113185654_add_user_email_to_worker_logs.data_uploader.rb
@@ -1,0 +1,6 @@
+# This migration comes from data_uploader (originally 20181113183506)
+class AddUserEmailToWorkerLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :worker_logs, :user_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_12_110119) do
+ActiveRecord::Schema.define(version: 2018_11_13_185654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -389,6 +389,7 @@ ActiveRecord::Schema.define(version: 2018_11_12_110119) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "error"
+    t.string "user_email"
     t.index ["jid"], name: "index_worker_logs_on_jid"
     t.index ["section_id"], name: "index_worker_logs_on_section_id"
   end


### PR DESCRIPTION
* Install migration from data uploader gem
* Update pages in active admin (done with a rake task) -> template in the gem has been updated

Dependent on this this branch in `climate-watch-gems` -> https://github.com/ClimateWatch-Vizzuality/climate-watch-gems/pull/16

Once the branch on cw-gems is merged, Gemfile needs to be updated to uncomment this line:
`# gem 'cw_data_uploader', '~> 0.3.3', require: 'data_uploader'`