### PR TITLE
Updates code to display GHG Inventory data

### DIFF
--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-selectors.js
@@ -13,6 +13,7 @@ const dataNames = {
   yMPAWOM: 'Scenario_MPA - WOM',
   yMPAWEM: 'Scenario_MPA_WEM',
   yLTMS: 'Scenario_LTMS',
+  yGHGInventory: 'GHG Inventory',
   yPPD: [ 'Scenario_PPD_L', 'Scenario_PPD_U' ],
   yBAU: [ 'Scenario_BAU_L', 'Scenario_BAU_U' ]
 };
@@ -53,8 +54,9 @@ const parseData = createSelector(getProjectedEmissionsData, data => {
           const columnYearsData = index
             ? columnData[name][index]
             : columnData[name];
-          return columnYearsData.find(v => v.year === year).value *
-            API_DATA_SCALE;
+          const valForYear = columnYearsData.find(v => v.year === year);
+
+          return valForYear ? valForYear.value * API_DATA_SCALE : undefined;
         };
         if (isArray(columnData[columnName][0])) {
           columnsYearData[columnName] = [
@@ -72,7 +74,7 @@ const parseData = createSelector(getProjectedEmissionsData, data => {
 
 const getModelOptions = () => [
   {
-    query: 'GHGInventory',
+    query: 'GHG Inventory',
     label: 'GHG Inventory',
     type: 'dots',
     value: 'yGHGInventory'


### PR DESCRIPTION
This PR updates Projected emissions to display the GHG Inventory data that is now available for this section.

You need to re-import your projected emissions data with:

`bundle exec rails ghg:import`

And then visit http://localhost:3000/ghg-emissions/projected-emissions

I had to make the code resilient to datasets without all the years of data, so made a small tweak there. (GHG Inventory only has two data points for the range displayed).