### PR TITLE
Renames GHG emissions to Projected Emissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 git 'https://github.com/ClimateWatch-Vizzuality/climate-watch-gems.git' do
-  gem 'climate_watch_engine', '~> 1.4.0'
+  gem 'climate_watch_engine', '~> 1.4.1'
   gem 'cw_locations', '~> 1.4.0', require: 'locations'
   gem 'cw_historical_emissions', '~> 1.5.0', require: 'historical_emissions'
   gem 'cw_data_uploader', '~> 0.4.1', require: 'data_uploader'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,7 @@ DEPENDENCIES
   annotate
   byebug
   capybara (~> 2.13)
-  climate_watch_engine (~> 1.4.0)!
+  climate_watch_engine (~> 1.4.1)!
   cw_data_uploader (~> 0.4.1)!
   cw_historical_emissions (~> 1.5.0)!
   cw_locations (~> 1.4.0)!

--- a/app/admin/south_africa_platform/ghg_emissions.rb
+++ b/app/admin/south_africa_platform/ghg_emissions.rb
@@ -1,12 +1,12 @@
-ActiveAdmin.register_page 'South Africa Platform Ghg Emissions' do
+ActiveAdmin.register_page 'South Africa Platform - Projected Emissions' do
   include DataUploader::SharedAdmin
 
-  section_name = 'ghg_emissions'
+  section_name = 'projected_emissions'
   platform_name = 'south_africa_platform'
 
   controller do
     def section_name
-      'ghg_emissions'
+      'projected_emissions'
     end
 
     def platform_name
@@ -14,11 +14,11 @@ ActiveAdmin.register_page 'South Africa Platform Ghg Emissions' do
     end
 
     def s3_folder_path
-      "#{CW_FILES_PREFIX}ghg_emissions"
+      "#{CW_FILES_PREFIX}projected_emissions"
     end
 
     def path
-      admin_south_africa_platform_ghg_emissions_path
+      admin_south_africa_platform_projected_emissions_path
     end
 
     def section
@@ -29,7 +29,7 @@ ActiveAdmin.register_page 'South Africa Platform Ghg Emissions' do
     end
 
     def import_worker
-      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportGhg', current_admin_user.email)
+      DataUploader::BaseImportWorker.perform_async(section.id, 'ImportProjectedEmissions', current_admin_user.email)
     end
 
     def section_repository
@@ -59,11 +59,11 @@ ActiveAdmin.register_page 'South Africa Platform Ghg Emissions' do
   content do
     render partial: 'data_uploader/admin/form_upload_datasets', locals: {
       datasets: datasets_proc.call,
-      upload_path: admin_south_africa_platform_ghg_emissions_upload_datafile_path,
-      download_path: admin_south_africa_platform_ghg_emissions_download_datafiles_path,
+      upload_path: admin_south_africa_platform_projected_emissions_upload_datafile_path,
+      download_path: admin_south_africa_platform_projected_emissions_download_datafiles_path,
       download_single_data_file_path:
-          admin_south_africa_platform_ghg_emissions_download_datafile_path,
-      import_path: admin_south_africa_platform_ghg_emissions_run_importer_path,
+          admin_south_africa_platform_projected_emissions_download_datafile_path,
+      import_path: admin_south_africa_platform_projected_emissions_run_importer_path,
       import_button_disabled: section_proc.call.worker_logs.started.any?,
       logs: section_proc.call.worker_logs.order(created_at: :desc)
     }

--- a/app/services/import_projected_emissions.rb
+++ b/app/services/import_projected_emissions.rb
@@ -1,7 +1,7 @@
-class ImportGhg
-  PROJECTED_EMISSIONS_FILEPATH = "#{CW_FILES_PREFIX}ghg_emissions/projected_emissions.csv".freeze
+class ImportProjectedEmissions
+  PROJECTED_EMISSIONS_FILEPATH = "#{CW_FILES_PREFIX}projected_emissions/projected_emissions.csv".freeze
   PROJECTED_EMISSIONS_METADATA_FILEPATH =
-    "#{CW_FILES_PREFIX}ghg_emissions/projected_emissions_metadata.csv".freeze
+    "#{CW_FILES_PREFIX}projected_emissions/projected_emissions_metadata.csv".freeze
 
   def call
     cleanup

--- a/config/data_uploader.yml
+++ b/config/data_uploader.yml
@@ -10,14 +10,14 @@ platforms:
         importer: ImportDataSource
         datasets:
           - data_sources
-      - name: financial_resources 
+      - name: financial_resources
         importer: ImportFinancialResource
         datasets:
           - support_needs
           - support_received
           - financial_indicators
-      - name: ghg_emissions
-        importer: ImportGhg
+      - name: projected_emissions
+        importer: ImportProjectedEmissions
         datasets:
           - projected_emissions
           - projected_emissions_metadata

--- a/lib/tasks/ghg.rake
+++ b/lib/tasks/ghg.rake
@@ -1,8 +1,0 @@
-namespace :ghg do
-  desc 'Imports ghg data from the csv sources'
-  task import: :environment do
-    TimedLogger.log('import ghg data') do
-      ImportGhg.new.call
-    end
-  end
-end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -4,7 +4,7 @@ namespace :db do
     Rake::Task['locations:import'].invoke
     Rake::Task['location_members:import'].invoke
     Rake::Task['financial_resource:import'].invoke
-    Rake::Task['ghg:import'].invoke
+    Rake::Task['projected_emissions:import'].invoke
     Rake::Task['inventory_improvement:import'].invoke
     Rake::Task['national_circumstances:import'].invoke
     Rake::Task['mitigation:import'].invoke

--- a/lib/tasks/projected_emissions.rake
+++ b/lib/tasks/projected_emissions.rake
@@ -1,0 +1,8 @@
+namespace :projected_emissions do
+  desc 'Imports projected_emissions data from the csv sources'
+  task import: :environment do
+    TimedLogger.log('import projected emissions data') do
+      ImportProjectedEmissions.new.call
+    end
+  end
+end


### PR DESCRIPTION
The thing previously named GHG Emissions was actually Projected Emissions, but this was making things weird on the backend admin side. This PR renames it to have the proper name and remove confusion.

You will need to run:

`rails db:admin_boilerplate:create`

Because you might have the section called GHG Emissions when running this task it will break... unless this PR is merged: https://github.com/ClimateWatch-Vizzuality/climate-watch-gems/pull/21, then you'll need to update the Gem version of `cw_data_uploader` on the Gemfile to: `0.3.6`, bundle install and commit the Gemfile and Gemfile.lock. And all should work! =)

Cheers,
Simão