### PR TITLE
Fix/charts x y axes unit labels

### DIFF
--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
@@ -83,6 +83,7 @@ class TotalGhgEmissions extends PureComponent {
               customMessage="Emissions data not available"
               hideRemoveOptions
               {...chartData}
+              showUnit
             />
           </div>
           <TabletPortraitOnly>

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -131,6 +131,7 @@ class GHGHistoricalEmissions extends PureComponent {
               customMessage="Emissions data not available"
               onLegendChange={v => this.handleFieldChange('sector', v)}
               {...chartData}
+              showUnit
             />
           </div>
           <TabletPortraitOnly>

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
@@ -137,6 +137,7 @@ class ProjectedEmissions extends PureComponent {
             onLegendChange={this.handleModelChange}
             getCustomYLabelFormat={value =>
                   format('~s')(value).replace('G', 'B')}
+            showUnit
           >
             {this.renderRangedAreas()}
             {this.renderLinesWithDots()}

--- a/app/javascript/app/pages/national-circumstances/economy/gdp-growth/gdp-growth-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/economy/gdp-growth/gdp-growth-component.jsx
@@ -57,6 +57,7 @@ class GDPGrowth extends PureComponent {
               customYAxisTick={<CustomYAxisTick />}
               customTooltip={<GdpTooltip />}
               areaAsBackgroundForCartesianGrid={greyArea}
+              showUnit
             >
               {lineChart}
             </ChartComposed>

--- a/app/javascript/app/pages/national-circumstances/economy/gdp-growth/gdp-growth-selectors.js
+++ b/app/javascript/app/pages/national-circumstances/economy/gdp-growth/gdp-growth-selectors.js
@@ -27,7 +27,7 @@ const getChartData = createSelector(filterGDPGrowthData, data => {
     config: {
       axes: {
         xBottom: { name: 'Year', unit: 'date', format: 'YYYY' },
-        yLeft: { name: 'GDP Growth', format: 'number', unit: '' }
+        yLeft: { name: 'GDP Growth', format: 'number', unit: '% growth' }
       },
       theme: { yG: { stroke: '#0E9560', fill: '#0E9560' }, greyArea: {} },
       tooltip: { yG: { label: 'GDP Growth' }, greyArea: { label: '' } },

--- a/app/javascript/app/pages/national-circumstances/economy/gdp/gdp-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/economy/gdp/gdp-component.jsx
@@ -64,6 +64,7 @@ class GDP extends PureComponent {
                   customTooltip={<CustomTooltip />}
                   customYAxisTick={<CustomYAxisTick />}
                   {...chartData}
+                  showUnit
                 />
               )
           }

--- a/app/javascript/app/pages/national-circumstances/economy/gdp/gdp-selectors.js
+++ b/app/javascript/app/pages/national-circumstances/economy/gdp/gdp-selectors.js
@@ -108,11 +108,13 @@ export const getChartConfig = createSelector(
       {}
     );
     let title = 'USD';
+    let unit = 'USD';
     let suffix = 'billion';
     let scale = 1 / API_GDP_DATA_SCALE;
 
     if (metricSelected.value === METRIC_OPTIONS.PER_CAPITA.value) {
       title = `${title} per capita`;
+      unit = `${unit} per capita`;
       suffix = '';
       scale = 1;
     }
@@ -125,7 +127,7 @@ export const getChartConfig = createSelector(
     };
     const axes = {
       xBottom: DEFAULT_AXES_CONFIG.xBottom,
-      yLeft: { name: 'USD', title }
+      yLeft: { name: 'USD', title, unit }
     };
     return {
       axes,

--- a/app/javascript/app/pages/national-circumstances/economy/human-development-index/human-development-index-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/economy/human-development-index/human-development-index-component.jsx
@@ -36,6 +36,7 @@ class HumanDevelopmentIndex extends PureComponent {
                   customYAxisTick={<CustomYAxisTick />}
                   customTooltip={<HdiTooltip />}
                   {...chartData}
+                  showUnit
                 />
               )
           }

--- a/app/javascript/app/pages/national-circumstances/economy/human-development-index/human-development-index-selectors.js
+++ b/app/javascript/app/pages/national-circumstances/economy/human-development-index/human-development-index-selectors.js
@@ -55,7 +55,7 @@ const getChartData = createSelector(
       config: {
         axes: {
           xBottom: { name: 'Year', unit: 'date', format: 'YYYY' },
-          yLeft: { name: 'HDI', unit: '', format: 'number' }
+          yLeft: { name: 'HDI', unit: 'HDI', format: 'number' }
         },
         theme: {
           yZAF: { stroke: '#0E9560', fill: '#0E9560' },

--- a/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
@@ -91,6 +91,7 @@ class Energy extends PureComponent {
               onLegendChange={this.handleSectorChange}
               getCustomYLabelFormat={value => format('~s')(value)}
               {...chartData}
+              showUnit
             />
           </div>
           <TabletPortraitOnly>

--- a/app/javascript/app/pages/national-circumstances/energy/energy-selectors.js
+++ b/app/javascript/app/pages/national-circumstances/energy/energy-selectors.js
@@ -140,7 +140,7 @@ export const parseChartData = createSelector(
   ],
   (data, metricSelected, calculationData, chartType) => {
     if (!data || isEmpty(data)) return null;
-    const isPercentageChart = chartType.value === 'Percentage chart';
+    const isPercentageChart = chartType.value === 'percentage';
     let xValues = data[0].categoryYears.map(d => d.year);
     if (
       !isPercentageChart &&
@@ -173,8 +173,8 @@ export const parseChartData = createSelector(
 );
 
 export const getChartConfig = createSelector(
-  [ getMetricSelected, getSectorSelected ],
-  (metricSelected, sectors) => {
+  [ getMetricSelected, getSectorSelected, getChartTypeSelected ],
+  (metricSelected, sectors, chartTypeSelected) => {
     if (!sectors) return null;
     const yColumns = sectors.map(d => ({
       label: d.value,
@@ -191,12 +191,16 @@ export const getChartConfig = createSelector(
       {}
     );
     const tooltip = getTooltipConfig(yColumns);
-    let unit = '';
-    if (metricSelected.value === METRIC_OPTIONS.PER_GDP.value) {
+    let unit = 'Joules';
+
+    if (chartTypeSelected.value === 'percentage') {
+      unit = `% ${unit}`;
+    } else if (metricSelected.value === METRIC_OPTIONS.PER_GDP.value) {
       unit = `Joules per million $`;
     } else if (metricSelected.value === METRIC_OPTIONS.PER_CAPITA.value) {
       unit = `Joules per capita`;
     }
+
     const axes = {
       ...DEFAULT_AXES_CONFIG,
       yLeft: { ...DEFAULT_AXES_CONFIG.yLeft, unit, suffix: 'J' }

--- a/app/javascript/app/pages/national-circumstances/population/distribution-by-age/distribution-by-age-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/population/distribution-by-age/distribution-by-age-component.jsx
@@ -59,6 +59,7 @@ class PopulationTab extends PureComponent {
           domain={domain}
           height={500}
           customMessage="No data"
+          showUnit
         />
         <TabletPortraitOnly>
           {toolbar}

--- a/app/javascript/app/pages/national-circumstances/population/distribution-by-age/distribution-by-age-selectors.js
+++ b/app/javascript/app/pages/national-circumstances/population/distribution-by-age/distribution-by-age-selectors.js
@@ -56,8 +56,18 @@ const getBarChartData = createSelector(
       domain: { x: [ 'auto', 'auto' ], y: [ 0, 'auto' ] },
       config: {
         axes: {
-          xBottom: { name: 'Age distribution', unit: '', format: 'string' },
-          yLeft: { name: 'Number of people', unit: '', format: 'number' }
+          xBottom: {
+            name: 'Age distribution',
+            unit: 'age',
+            format: 'string',
+            label: { dx: 5, dy: 0 }
+          },
+          yLeft: {
+            name: 'Number of people',
+            unit: 'people',
+            format: 'number',
+            label: { dx: 0, dy: 14 }
+          }
         },
         tooltip: { y: { label: 'people' } },
         animation: false,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-preset-stage-2": "6.24.1",
     "classnames": "2.2.5",
     "core-js": "2.5.3",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.20.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.21.0",
     "d3": "^5.7.0",
     "dotenv": "4.0.0",
     "es6-promise": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-preset-stage-2": "6.24.1",
     "classnames": "2.2.5",
     "core-js": "2.5.3",
-    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.17.0",
+    "cw-components": "github:ClimateWatch-Vizzuality/climate-watch-components#1.20.0",
     "d3": "^5.7.0",
     "dotenv": "4.0.0",
     "es6-promise": "^4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,9 +2640,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.20.0":
-  version "1.20.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/6f7c419292d7458a4950f309a202a2388e425b96"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.21.0":
+  version "1.21.0"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/6bb790297c8862a380b99ddeb895bfb2ea4ab8dc"
   dependencies:
     d3-format "1.3.0"
     d3-hierarchy "^1.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2640,9 +2640,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.17.0":
-  version "1.17.0"
-  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/278192a8780d8e5c022f94ee979523014965d577"
+"cw-components@github:ClimateWatch-Vizzuality/climate-watch-components#1.20.0":
+  version "1.20.0"
+  resolved "https://codeload.github.com/ClimateWatch-Vizzuality/climate-watch-components/tar.gz/6f7c419292d7458a4950f309a202a2388e425b96"
   dependencies:
     d3-format "1.3.0"
     d3-hierarchy "^1.1.8"


### PR DESCRIPTION
- Add to each every chart with y-axis unit label on the top
- For `National Circumstances/Population/Distribution by age` add also x-axis unit label:
![screenshot from 2018-11-26 16-44-01](https://user-images.githubusercontent.com/15097138/49028573-9d3bce00-f19a-11e8-9efc-6154532cce47.png)
- For some charts, like `National Circumstances/Energy` y-axis label will change according to selected filter option in dropdowns:
![national circumstances energy](https://user-images.githubusercontent.com/15097138/49027903-14706280-f199-11e8-97fb-3809afc9c51c.png)

List of changed charts:
- Overview
	- Historical Emission
- National circumstances
	- Population/Distribution by age
	- Economy
		- GDP
		- GDP Growth
		- Human Development Index
	- Energy
- GHG Emission
	- Historical emissions
	-  Projected Emissions