### PR TITLE
Fix/select province in default view

### DIFF
--- a/app/javascript/app/components/map/map-component.jsx
+++ b/app/javascript/app/components/map/map-component.jsx
@@ -92,7 +92,6 @@ class Map extends Component {
           getContent={name => {
             const regionPercentage = getValue(name, 'regionPercentage');
             const regionTotal = getValue(name, 'regionTotal');
-
             return `<div>
               <div class="${styles.regionName}">
                 ${name}

--- a/app/javascript/app/components/map/map-component.jsx
+++ b/app/javascript/app/components/map/map-component.jsx
@@ -22,8 +22,28 @@ class Map extends Component {
     );
   }
 
+  overwriteDefaultStyle = geographyName => {
+    const { defaultStyle, selectedTitle } = this.props;
+    const isSelected = selectedTitle === geographyName;
+    const { default: defaultOld } = defaultStyle;
+    const defaultNew = {
+      ...defaultOld,
+      fill: isSelected ? '#f5b335' : '#ecf0f1'
+    };
+    return { ...defaultStyle, default: defaultNew };
+  };
+
   render() {
-    const { style, theme, paths, events, defaultStyle, data } = this.props;
+    const {
+      style,
+      theme,
+      paths,
+      events,
+      defaultStyle,
+      data,
+      selectedTitle,
+      disableOptimization
+    } = this.props;
     const getValue = (name, slug) =>
       data && data[name] && data[name].find(d => d.slug === slug).value;
     return (
@@ -34,20 +54,30 @@ class Map extends Component {
             center={[ 27.66, -28.52 ]}
             onMoveEnd={this.handleMoveEnd}
           >
-            <Geographies geography={paths}>
+            <Geographies
+              geography={paths}
+              disableOptimization={disableOptimization}
+            >
               {(geographies, projection) =>
                 geographies.map(
-                  geography =>
+                  (geography, i) =>
                     geography &&
                       (
                         <Geography
                           key={geography.properties.name}
+                          cacheId={`geography-${i}`}
                           data-for="mapTooltip"
                           data-tip={geography.properties.name}
                           data-html
                           geography={geography}
                           projection={projection}
-                          style={geography.style || defaultStyle}
+                          style={
+                            geography.style || selectedTitle
+                              ? this.overwriteDefaultStyle(
+                                geography.properties.name
+                              )
+                              : defaultStyle
+                          }
                           {...events}
                         />
                       )
@@ -62,6 +92,7 @@ class Map extends Component {
           getContent={name => {
             const regionPercentage = getValue(name, 'regionPercentage');
             const regionTotal = getValue(name, 'regionTotal');
+
             return `<div>
               <div class="${styles.regionName}">
                 ${name}
@@ -85,7 +116,9 @@ Map.propTypes = {
   paths: PropTypes.array,
   defaultStyle: PropTypes.object,
   events: PropTypes.object,
-  data: PropTypes.object
+  data: PropTypes.object,
+  selectedTitle: PropTypes.string,
+  disableOptimization: PropTypes.bool
 };
 
 Map.defaultProps = {
@@ -113,7 +146,9 @@ Map.defaultProps = {
       strokeWidth: 0.1,
       outline: 'none'
     }
-  }
+  },
+  selectedTitle: null,
+  disableOptimization: false
 };
 
 export default Map;

--- a/app/javascript/app/pages/national-circumstances/provincial/provincial-development-priorities-content/provincial-development-priorities-content-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/provincial/provincial-development-priorities-content/provincial-development-priorities-content-component.jsx
@@ -34,6 +34,7 @@ class ProvincialDevelopmentPrioritiesContent extends PureComponent {
           {
             selectedData &&
               selectedData[title] &&
+              /* eslint-disable-next-line react/no-danger */
               (
                 <ul
                   className={styles.list}

--- a/app/javascript/app/pages/national-circumstances/provincial/provincial-development-priorities-content/provincial-development-priorities-content-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/provincial/provincial-development-priorities-content/provincial-development-priorities-content-component.jsx
@@ -24,13 +24,16 @@ class ProvincialDevelopmentPrioritiesContent extends PureComponent {
     const { selectedData } = this.props;
     return (
       <div className={styles.columns}>
-        <Map events={this.mapEvents} />
+        <Map
+          events={this.mapEvents}
+          selectedTitle={title}
+          disableOptimization
+        />
         <div>
           <h3 className={styles.title}>{title}</h3>
           {
             selectedData &&
               selectedData[title] &&
-              /* eslint-disable-next-line react/no-danger */
               (
                 <ul
                   className={styles.list}


### PR DESCRIPTION
Feedback: In a default view (Provincial Development Priorities), the province is not highlighted on the map.
- Now the selected province is highlighted; by selected I mean selected by default after page load or last hovered province on the map. I had to use [disableOptimization](https://github.com/zcreativelabs/react-simple-maps#Geographies-component) prop of the `react-simple-maps` package to allow Geography component changing `fill` attribute in real time.
![screenshot from 2018-12-04 12-46-10](https://user-images.githubusercontent.com/15097138/49442892-bc51e580-f7c2-11e8-9f50-d8ed14c6fe69.png)
