### PR TITLE
Fix/ghg emissions

### DIFF
--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -13,9 +13,30 @@ import { format } from 'd3-format';
 import styles from './historical-styles';
 
 class GHGHistoricalEmissions extends PureComponent {
+  handleLegendChange = values => {
+    const { onFilterChange, sectorOptions } = this.props;
+    const subSectors = [];
+    const sectors = [];
+    values.forEach(v => {
+      if (!sectorOptions.map(o => o.label).includes(v.label)) {
+        subSectors.push(v.value);
+      } else {
+        sectors.push(v.value);
+      }
+    });
+    onFilterChange({
+      sector: sectors.join(','),
+      subSector: subSectors.join(',')
+    });
+  };
+
   handleFieldChange = (field, values) => {
     const { onFilterChange } = this.props;
-    onFilterChange({ [field]: values.map(v => v.value).join(',') });
+    if (field === 'legendSector') {
+      this.handleLegendChange(values);
+    } else {
+      onFilterChange({ [field]: values.map(v => v.value).join(',') });
+    }
   };
 
   handleMetricChange = ({ value }) => {
@@ -111,7 +132,7 @@ class GHGHistoricalEmissions extends PureComponent {
               height={450}
               dots={false}
               customMessage="Emissions data not available"
-              onLegendChange={v => this.handleFieldChange('sector', v)}
+              onLegendChange={v => this.handleFieldChange('legendSector', v)}
               {...chartData}
               showUnit
               getCustomYLabelFormat={value => `${format('.2s')(`${value}`)}`}

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -4,6 +4,8 @@ import ModalMetadata from 'components/modal-metadata';
 import SectionTitle from 'components/section-title';
 import { TabletLandscape, TabletPortraitOnly } from 'components/responsive';
 import { Section, Multiselect, Dropdown } from 'cw-components';
+import { Line } from 'recharts';
+import has from 'lodash/has';
 import Chart from 'components/chart';
 import MetadataProvider from 'providers/metadata-provider';
 import GHGEmissionsProvider from 'providers/ghg-emissions-provider';
@@ -46,6 +48,48 @@ class GHGHistoricalEmissions extends PureComponent {
 
   handleDownloadClick = () => {
     console.info('TODO: link todownload data endpoint', this.props);
+  };
+
+  renderDotsLines = () => {
+    // eslint-disable-next-line react/destructuring-assignment
+    const { config } = this.props.chartData;
+    return config &&
+      has(config, 'columns.dots') &&
+      config.columns.dots.map(column => {
+        const color = config.theme[column.value].stroke || '';
+        return (
+          <Line
+            key={column.value}
+            dataKey={column.value}
+            stroke={color}
+            strokeDasharray="1,09"
+            strokeWidth="5"
+            strokeLinecap="round"
+            type="monotone"
+            dot={false}
+          />
+        );
+      });
+  };
+
+  renderLines = () => {
+    // eslint-disable-next-line react/destructuring-assignment
+    const { config } = this.props.chartData;
+    return config &&
+      has(config, 'columns.lines') &&
+      config.columns.lines.map(column => {
+        const color = config.theme[column.value].stroke || '';
+        return (
+          <Line
+            key={column.value}
+            dot={false}
+            dataKey={column.value}
+            stroke={color}
+            strokeWidth={2}
+            type="monotone"
+          />
+        );
+      });
   };
 
   render() {
@@ -127,17 +171,25 @@ class GHGHistoricalEmissions extends PureComponent {
             }}
           </TabletLandscape>
           <div className={styles.chart}>
-            <Chart
-              type="line"
-              height={450}
-              dots={false}
-              customMessage="Emissions data not available"
-              onLegendChange={v => this.handleFieldChange('legendSector', v)}
-              {...chartData}
-              showUnit
-              getCustomYLabelFormat={value => `${format('.2s')(`${value}`)}`}
-              lineType="linear"
-            />
+            {
+              chartData && chartData.config && (
+              <Chart
+                chartType="composed"
+                type="line"
+                height={450}
+                customMessage="Emissions data not available"
+                onLegendChange={v =>
+                      this.handleFieldChange('legendSector', v)}
+                {...chartData}
+                getCustomYLabelFormat={value =>
+                      `${format('.2s')(`${value}`).replace('G', 'B')}`}
+                showUnit
+              >
+                {this.renderDotsLines()}
+                {this.renderLines()}
+              </Chart>
+                )
+            }
           </div>
           <TabletPortraitOnly>
             {toolbar}

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -66,6 +66,7 @@ class GHGHistoricalEmissions extends PureComponent {
             strokeWidth="5"
             strokeLinecap="round"
             type="monotone"
+            isAnimationActive={false}
             dot={false}
           />
         );
@@ -86,6 +87,7 @@ class GHGHistoricalEmissions extends PureComponent {
             dataKey={column.value}
             stroke={color}
             strokeWidth={2}
+            isAnimationActive={false}
             type="monotone"
           />
         );
@@ -184,6 +186,7 @@ class GHGHistoricalEmissions extends PureComponent {
                 getCustomYLabelFormat={value =>
                       `${format('.2s')(`${value}`).replace('G', 'B')}`}
                 showUnit
+                isAnimationActive={false}
               >
                 {this.renderDotsLines()}
                 {this.renderLines()}

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -9,31 +9,13 @@ import MetadataProvider from 'providers/metadata-provider';
 import GHGEmissionsProvider from 'providers/ghg-emissions-provider';
 import WorldBankProvider from 'providers/world-bank-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
-
+import { format } from 'd3-format';
 import styles from './historical-styles';
 
 class GHGHistoricalEmissions extends PureComponent {
   handleFieldChange = (field, values) => {
-    const { onFilterChange, sectorOptions } = this.props;
-    if (values && values.length > 0) {
-      if (field === 'sector') {
-        const subSectors = [];
-        const sectors = [];
-        values.forEach(v => {
-          if (!sectorOptions.map(o => o.label).includes(v.label)) {
-            subSectors.push(v.value);
-          } else {
-            sectors.push(v.value);
-          }
-        });
-        onFilterChange({
-          sector: sectors.join(','),
-          subSector: subSectors.join(',')
-        });
-      } else {
-        onFilterChange({ [field]: values.map(v => v.value).join(',') });
-      }
-    }
+    const { onFilterChange } = this.props;
+    onFilterChange({ [field]: values.map(v => v.value).join(',') });
   };
 
   handleMetricChange = ({ value }) => {
@@ -132,6 +114,8 @@ class GHGHistoricalEmissions extends PureComponent {
               onLegendChange={v => this.handleFieldChange('sector', v)}
               {...chartData}
               showUnit
+              getCustomYLabelFormat={value => `${format('.2s')(`${value}`)}`}
+              lineType="linear"
             />
           </div>
           <TabletPortraitOnly>

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -134,7 +134,7 @@ export const getSubSectorSelected = createSelector(
   [ getSubSectorOptions, getSubSectorParam ],
   (subSectors, subSectorSelected) => {
     if (!subSectors) return null;
-    if (!subSectorSelected) return subSectors;
+    if (!subSectorSelected) return [];
     const sectorsParsed = subSectorSelected
       .split(',')
       .map(s => parseInt(s, 10));

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -155,8 +155,18 @@ const getCalculationData = createSelector([ getWBData ], data => {
   return groupBy(data, 'year');
 });
 
+const filterChartData = createSelector(
+  [ getEmissionsData, getSectorSelected, getSubSectorSelected ],
+  (data, sectorSelected, subSectorSelected) => {
+    if (!data) return null;
+    const sectorLabels = [ ...sectorSelected, ...subSectorSelected ].map(
+      s => s.label
+    );
+    return data.filter(d => sectorLabels.includes(d.sector));
+  }
+);
 export const parseChartData = createSelector(
-  [ getEmissionsData, getMetricSelected, getCalculationData ],
+  [ filterChartData, getMetricSelected, getCalculationData ],
   (emissionsData, metricSelected, calculationData) => {
     if (!emissionsData) return null;
     const [ data ] = emissionsData;

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -219,7 +219,7 @@ const getDataSelected = createSelector(
 );
 
 export const getChartConfig = createSelector(
-  [ getEmissionsData, getSectorSelected, getMetricSelected ],
+  [ filterChartData, getSectorSelected, getMetricSelected ],
   (data, sectorSelected, metricSelected) => {
     if (!data || !sectorSelected) return null;
     const getYOption = sectors =>

--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -61,9 +61,11 @@ export const getThemeConfig = (columns, colors = CHART_COLORS) => {
   columns.forEach((column, i) => {
     const index = column.index || i;
     const correctedIndex = index % colors.length;
+    const icon = column.icon ? { icon: column.icon } : {};
     theme[column.value] = {
       stroke: colors[correctedIndex],
-      fill: colors[correctedIndex]
+      fill: colors[correctedIndex],
+      ...icon
     };
   });
   return theme;


### PR DESCRIPTION
This PR fixes selection in Historical emissions chart and adds the distinction between sectors and subsectors in the chart and tooltip.

- Fix selection
- Dont select subsector by default https://basecamp.com/1756858/projects/13795275/todos/372959375
- Visual cues for sectors and subsectors

Note: There should be a second PR to use a multilevel-multiselect instead of the two dropdowns (sector, subsector)

![image](https://user-images.githubusercontent.com/9701591/49506726-11ebc800-f87f-11e8-8b0b-649699acb255.png)
