### PR TITLE
Fix/units correction

### DIFF
--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -9,7 +9,7 @@ import MetadataProvider from 'providers/metadata-provider';
 import GHGEmissionsProvider from 'providers/ghg-emissions-provider';
 import WorldBankProvider from 'providers/world-bank-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
-
+import { format } from 'd3-format';
 import styles from './historical-styles';
 
 class GHGHistoricalEmissions extends PureComponent {
@@ -130,6 +130,7 @@ class GHGHistoricalEmissions extends PureComponent {
               dots={false}
               customMessage="Emissions data not available"
               onLegendChange={v => this.handleFieldChange('sector', v)}
+              getCustomYLabelFormat={value => format('~d')(value)}
               {...chartData}
               showUnit
             />

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -181,8 +181,8 @@ export const parseChartData = createSelector(
           x
         );
         if (yData && yData.value) {
-          // 1000000 is the data scale from the API
-          yItems[yKey] = yData.value * 1000000 / calculationRatio;
+          // data is in kt, we want Mt so we have to divide value by 1000
+          yItems[yKey] = yData.value / 1000 / calculationRatio;
         }
       });
       const item = { x, ...yItems };
@@ -231,7 +231,7 @@ export const getChartConfig = createSelector(
     }
     const axes = {
       ...DEFAULT_AXES_CONFIG,
-      yLeft: { ...DEFAULT_AXES_CONFIG.yLeft, unit }
+      yLeft: { ...DEFAULT_AXES_CONFIG.yLeft, unit: `Mt${unit}` }
     };
     return {
       axes,

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
@@ -135,7 +135,7 @@ class ProjectedEmissions extends PureComponent {
             height={500}
             {...chartData}
             onLegendChange={this.handleModelChange}
-            getCustomYLabelFormat={value => format('~r')(value / 1000000)}
+            getCustomYLabelFormat={value => format('~r')(value)}
             showUnit
           >
             {this.renderRangedAreas()}

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
@@ -135,8 +135,7 @@ class ProjectedEmissions extends PureComponent {
             height={500}
             {...chartData}
             onLegendChange={this.handleModelChange}
-            getCustomYLabelFormat={value =>
-                  format('~s')(value).replace('G', 'B')}
+            getCustomYLabelFormat={value => format('~r')(value / 1000000)}
             showUnit
           >
             {this.renderRangedAreas()}

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-selectors.js
@@ -7,8 +7,6 @@ import rangeCircle from 'assets/icons/legend/range-circle.svg';
 import strippedLine from 'assets/icons/legend/stripped-line.svg';
 import wideLine from 'assets/icons/legend/wide-line.svg';
 
-const API_DATA_SCALE = 1000000;
-
 const dataNames = {
   yMPAWOM: 'Scenario_MPA - WOM',
   yMPAWEM: 'Scenario_MPA_WEM',
@@ -56,7 +54,7 @@ const parseData = createSelector(getProjectedEmissionsData, data => {
             : columnData[name];
           const valForYear = columnYearsData.find(v => v.year === year);
 
-          return valForYear ? valForYear.value * API_DATA_SCALE : undefined;
+          return valForYear ? valForYear.value : undefined;
         };
         if (isArray(columnData[columnName][0])) {
           columnsYearData[columnName] = [

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-selectors.js
@@ -154,7 +154,7 @@ const getChartData = createSelector(
           xBottom: { name: 'Year', unit: 'date', format: 'YYYY' },
           yLeft: {
             name: 'Emissions',
-            unit: 'CO<sub>2</sub>e',
+            unit: 'MtCO<sub>2</sub>e',
             format: 'number'
           }
         },


### PR DESCRIPTION
In reference to feedback [here](https://basecamp.com/1756858/projects/13795275/todos/373291400#events_todo_373291400) and [here](https://basecamp.com/1756858/projects/13795275/todos/373296440#events_todo_373296440) 
- Change unit and value format in Projected emission: from `CO2e` to `MtCO2e` and change format of value from decimal notation with an SI prefix `~s` to simple decimal notation `~r`.
![screenshot from 2018-12-06 10-07-15](https://user-images.githubusercontent.com/15097138/49577482-68b8d680-f93f-11e8-91af-95f0948e29bf.png)
- This same in Historical emissions, however, I noticed that our previous data scale was incorrect. From the backend, we get for example: 435117, but our api data scale was 1000000 what after multiplication give 435117000000 = 435Gt. And that is incorrect because 435117 is in the **kt** (kilotons), not **t**. To get a result in **Mt** we have to divide value by 1000