### PR TITLE
Fix/feedback fixes

### DIFF
--- a/app/javascript/app/components/download-box/download-box-component.jsx
+++ b/app/javascript/app/components/download-box/download-box-component.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Icon } from 'cw-components';
 import downloadIcon from 'assets/icons/download';
-
 import {
   FIRST_BIENNIAL_UPDATE_REPORT,
   SECOND_BIENNIAL_UPDATE_REPORT
@@ -19,26 +18,23 @@ class DownloadBox extends PureComponent {
         <div className={styles.downloadBoxTitle}>
           Download
         </div>
-        <div className={styles.downloadRow}>
-          <span className={styles.fileTitle}>
-            South Africas 2nd Biennial Update Report
-          </span>
-          <Icon
-            onClick={() =>
-              this.handleDownloadClick(SECOND_BIENNIAL_UPDATE_REPORT)}
-            icon={downloadIcon}
-          />
-        </div>
-        <div className={styles.downloadRow}>
-          <span className={styles.fileTitle}>
-            South Africas 1st Biennial Update Report
-          </span>
-          <Icon
-            onClick={() =>
-              this.handleDownloadClick(FIRST_BIENNIAL_UPDATE_REPORT)}
-            icon={downloadIcon}
-          />
-        </div>
+        <button
+          type="button"
+          className={styles.downloadRow}
+          onClick={() =>
+            this.handleDownloadClick(SECOND_BIENNIAL_UPDATE_REPORT)}
+        >
+          <span>South Africas 2nd Biennial Update Report</span>
+          <Icon icon={downloadIcon} />
+        </button>
+        <button
+          type="button"
+          className={styles.downloadRow}
+          onClick={() => this.handleDownloadClick(FIRST_BIENNIAL_UPDATE_REPORT)}
+        >
+          <span>South Africas 1st Biennial Update Report</span>
+          <Icon icon={downloadIcon} />
+        </button>
       </div>
     );
   }

--- a/app/javascript/app/components/download-box/download-box-styles.scss
+++ b/app/javascript/app/components/download-box/download-box-styles.scss
@@ -15,11 +15,19 @@
 }
 
 .downloadRow {
+  color: black;
   display: flex;
   margin-bottom: 20px;
   align-items: center;
   justify-content: space-between;
   font-size: $font-size-xs;
   font-family: $font-family-1;
+  text-align: left;
+  &::-moz-focus-inner {
+    border: 0;
+  }
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
 }
-

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -157,8 +157,7 @@ class GHGHistoricalEmissions extends PureComponent {
                 customMessage="Emissions data not available"
                 onLegendChange={v => this.handleFieldChange('sector', v)}
                 {...chartData}
-                getCustomYLabelFormat={value =>
-                      `${format('.2s')(`${value}`).replace('G', 'B')}`}
+                getCustomYLabelFormat={value => format('~d')(value)}
                 showUnit
                 isAnimationActive={false}
               >


### PR DESCRIPTION
In reference to [this](https://basecamp.com/1756858/projects/13795275/todos/373247467) and [this](https://basecamp.com/1756858/projects/13795275/todos/373291400):
- Now the text in download section is clickable:
![screenshot from 2018-12-06 18-38-32](https://user-images.githubusercontent.com/15097138/49604685-7e9dba00-f986-11e8-9ce5-e9297e041b79.png)
- A value in GHG Emissions/Historical Emissions is rounded properly, i.e. 435 instead of 440 (the right format was overidden by previous merge conflicts):
![screenshot from 2018-12-06 18-42-11](https://user-images.githubusercontent.com/15097138/49604865-f4098a80-f986-11e8-9eb5-fd59b789ce26.png)
