### PR TITLE
Feedback fixes

### DIFF
--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
@@ -9,6 +9,7 @@ import MetaProvider from 'providers/metadata-provider';
 import GHGEmissionsProvider from 'providers/ghg-emissions-provider';
 import WorldBankProvider from 'providers/world-bank-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
+import { format } from 'd3-format';
 
 import styles from './total-ghg-emissions-styles';
 
@@ -82,6 +83,7 @@ class TotalGhgEmissions extends PureComponent {
               dots={false}
               customMessage="Emissions data not available"
               hideRemoveOptions
+              getCustomYLabelFormat={value => format('~d')(value / 1000000)}
               {...chartData}
               showUnit
             />

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
@@ -10,7 +10,7 @@ import GHGEmissionsProvider from 'providers/ghg-emissions-provider';
 import WorldBankProvider from 'providers/world-bank-provider';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
 import { format } from 'd3-format';
-
+import { has } from 'lodash';
 import styles from './total-ghg-emissions-styles';
 
 class TotalGhgEmissions extends PureComponent {
@@ -27,7 +27,12 @@ class TotalGhgEmissions extends PureComponent {
       chartData,
       contentData
     } = this.props;
-
+    const scale = has(chartData, 'config.axes.yLeft.scale')
+      ? chartData.config.axes.yLeft.scale
+      : 1;
+    const d3Format = has(chartData, 'config.axes.yLeft.format')
+      ? chartData.config.axes.yLeft.format
+      : '~d';
     const dropdown = (
       <Dropdown
         theme={{ wrapper: styles.dropdown }}
@@ -83,7 +88,7 @@ class TotalGhgEmissions extends PureComponent {
               dots={false}
               customMessage="Emissions data not available"
               hideRemoveOptions
-              getCustomYLabelFormat={value => format('~d')(value / 1000000)}
+              getCustomYLabelFormat={value => format(d3Format)(value / scale)}
               {...chartData}
               showUnit
             />

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
@@ -141,7 +141,7 @@ export const getChartConfig = createSelector(
       unit = `${unit}/ million $ GDP`;
     } else if (metricSelected.value === METRIC_OPTIONS.PER_CAPITA.value) {
       unit = `${unit} per capita`;
-      format = '.3';
+      format = '.2~f';
     } else {
       unit = `Mt${unit}`;
       scale = 1000000;

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
@@ -10,7 +10,7 @@ import {
 
 const { COUNTRY_ISO } = process.env;
 const defaults = { gas: 'All GHG', source: 'DEA2017b', sector: 'Energy' };
-const fiteredSectors = [
+const filteredSectors = [
   'Energy',
   'Waste',
   'Agriculture, Forestry, and Other Land Use',
@@ -33,11 +33,10 @@ const getSectionContent = ({ SectionsContent }) =>
 
 const getTotalEmissionByYear = createSelector(getEmissionsData, data => {
   if (!data) return [];
-  const emissionsArr = flatten(
-    data
-      .filter(({ sector }) => fiteredSectors.includes(sector))
-      .map(({ emissions }) => emissions)
+  const filteredData = data.filter(
+    ({ sector }) => filteredSectors.includes(sector)
   );
+  const emissionsArr = flatten(filteredData.map(({ emissions }) => emissions));
   const emissionsByYear = groupBy(emissionsArr, 'year');
   return Object
     .keys(emissionsByYear)

--- a/app/javascript/app/pages/financial-resources/support-received/comparison-chart/comparison-chart-selectors.js
+++ b/app/javascript/app/pages/financial-resources/support-received/comparison-chart/comparison-chart-selectors.js
@@ -52,7 +52,7 @@ const getSelectedDataInfo = createSelector(
 
 export const getConfig = () => ({
   scale: 1 / 1000000,
-  suffix: 'm',
+  suffix: '',
   format: '~r'
 });
 

--- a/app/javascript/app/pages/financial-resources/support-received/flows-chart/flows-chart-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/flows-chart/flows-chart-component.jsx
@@ -8,7 +8,7 @@ const renderTooltipChildren = selectedChildrenData =>
   has(selectedChildrenData, 'payload.payload.focus')
     ? (
       <p className={styles.focus}>
-        {`Focus: ${selectedChildrenData.payload.payload.focus}`}
+        {`Focus: ${selectedChildrenData.payload.payload.focus.join(', ')}`}
       </p>
 )
     : null;

--- a/app/javascript/app/pages/financial-resources/support-received/flows-chart/flows-chart-selectors.js
+++ b/app/javascript/app/pages/financial-resources/support-received/flows-chart/flows-chart-selectors.js
@@ -77,8 +77,7 @@ export const addColorToData = createSelector(filterData, data => {
 export const getConfig = () => {
   const unit = 'USD million';
   const scale = 1 / 1000000;
-  const suffix = 'm';
-  return { tooltip: { unit, scale, suffix }, node: { unit, scale, suffix } };
+  return { tooltip: { unit, scale }, node: { unit, scale } };
 };
 
 export const getFlowsChart = createStructuredSelector({

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -93,6 +93,12 @@ class GHGHistoricalEmissions extends PureComponent {
       title,
       description
     } = this.props;
+    const scale = has(chartData, 'config.axes.yLeft.scale')
+      ? chartData.config.axes.yLeft.scale
+      : 1;
+    const d3Format = has(chartData, 'config.axes.yLeft.format')
+      ? chartData.config.axes.yLeft.format
+      : '~d';
     const dropdowns = (
       <div className={styles.dropdowWrapper}>
         <MultiDropdown
@@ -157,7 +163,8 @@ class GHGHistoricalEmissions extends PureComponent {
                 customMessage="Emissions data not available"
                 onLegendChange={v => this.handleFieldChange('sector', v)}
                 {...chartData}
-                getCustomYLabelFormat={value => format('~d')(value)}
+                getCustomYLabelFormat={value =>
+                      format(d3Format)(value / scale)}
                 showUnit
                 isAnimationActive={false}
               >

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -191,16 +191,12 @@ export const parseChartData = createSelector(
         const yData = d.emissions.find(e => e.year === x);
         const calculationRatio = getMetricRatio(
           metricSelected.value,
-          calculationData
+          calculationData,
+          x
         );
         if (yData && yData.value) {
-          // data is in kt, we want Mt so we have to divide value by 1000
-          // if(metricSelected.value === METRIC_OPTIONS.ABSOLUTE_VALUE.value)
-          yItems[yKey] = yData.value / 1000 / calculationRatio;
-          // else
-          //   // yItems[yKey] = yData.value * 1000 / calculationRatio;
-          //   yItems[yKey] = yData.value * 1000 / 375349;
-          // console.log(yData.value, 'kt ',(yData.value * 1000), 't, calculationRatio: ',calculationRatio,' items: ',yItems[yKey]);
+          // 1000 is the data scale from the API, originally value is in kt
+          yItems[yKey] = yData.value * 1000 / calculationRatio;
         }
       });
       const item = { x, ...yItems };
@@ -259,16 +255,20 @@ export const getChartConfig = createSelector(
       ...yColumnDotsOptions
     ]);
     let { unit } = DEFAULT_AXES_CONFIG.yLeft;
+    let scale = 1;
+    let format = '~d';
     if (metricSelected.value === METRIC_OPTIONS.PER_GDP.value) {
       unit = `${unit}/ million $ GDP`;
     } else if (metricSelected.value === METRIC_OPTIONS.PER_CAPITA.value) {
       unit = `${unit} per capita`;
+      format = '.2~f';
     } else {
       unit = `Mt${unit}`;
+      scale = 1000000;
     }
     const axes = {
       ...DEFAULT_AXES_CONFIG,
-      yLeft: { ...DEFAULT_AXES_CONFIG.yLeft, unit }
+      yLeft: { ...DEFAULT_AXES_CONFIG.yLeft, unit, scale, format }
     };
     return {
       axes,

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -191,13 +191,12 @@ export const parseChartData = createSelector(
         const yData = d.emissions.find(e => e.year === x);
         const calculationRatio = getMetricRatio(
           metricSelected.value,
-          calculationData,
-          
+          calculationData
         );
         if (yData && yData.value) {
           // data is in kt, we want Mt so we have to divide value by 1000
           // if(metricSelected.value === METRIC_OPTIONS.ABSOLUTE_VALUE.value)
-            yItems[yKey] = yData.value / 1000 / calculationRatio;
+          yItems[yKey] = yData.value / 1000 / calculationRatio;
           // else
           //   // yItems[yKey] = yData.value * 1000 / calculationRatio;
           //   yItems[yKey] = yData.value * 1000 / 375349;

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -192,11 +192,16 @@ export const parseChartData = createSelector(
         const calculationRatio = getMetricRatio(
           metricSelected.value,
           calculationData,
-          x
+          
         );
         if (yData && yData.value) {
           // data is in kt, we want Mt so we have to divide value by 1000
-          yItems[yKey] = yData.value / 1000 / calculationRatio;
+          // if(metricSelected.value === METRIC_OPTIONS.ABSOLUTE_VALUE.value)
+            yItems[yKey] = yData.value / 1000 / calculationRatio;
+          // else
+          //   // yItems[yKey] = yData.value * 1000 / calculationRatio;
+          //   yItems[yKey] = yData.value * 1000 / 375349;
+          // console.log(yData.value, 'kt ',(yData.value * 1000), 't, calculationRatio: ',calculationRatio,' items: ',yItems[yKey]);
         }
       });
       const item = { x, ...yItems };
@@ -259,10 +264,12 @@ export const getChartConfig = createSelector(
       unit = `${unit}/ million $ GDP`;
     } else if (metricSelected.value === METRIC_OPTIONS.PER_CAPITA.value) {
       unit = `${unit} per capita`;
+    } else {
+      unit = `Mt${unit}`;
     }
     const axes = {
       ...DEFAULT_AXES_CONFIG,
-      yLeft: { ...DEFAULT_AXES_CONFIG.yLeft, unit: `Mt${unit}` }
+      yLeft: { ...DEFAULT_AXES_CONFIG.yLeft, unit }
     };
     return {
       axes,

--- a/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-selectors.js
+++ b/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-selectors.js
@@ -27,7 +27,7 @@ const defaultColumns = [
   'status',
   'actor',
   'time_horizon',
-  'ghg',
+  'GHG',
   'estimated_emissions_reduction',
   'cobenefits'
 ];

--- a/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
@@ -125,7 +125,7 @@ Energy.propTypes = {
 Energy.defaultProps = {
   chartData: {},
   chartTypeOptions: [],
-  chartTypeSelected: 'area',
+  chartTypeSelected: null,
   chartType: 'line',
   sourceOptions: [],
   sourceSelected: null,

--- a/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
@@ -125,7 +125,7 @@ Energy.propTypes = {
 Energy.defaultProps = {
   chartData: {},
   chartTypeOptions: [],
-  chartTypeSelected: null,
+  chartTypeSelected: 'area',
   chartType: 'line',
   sourceOptions: [],
   sourceSelected: null,

--- a/app/javascript/app/pages/national-circumstances/energy/energy-selectors.js
+++ b/app/javascript/app/pages/national-circumstances/energy/energy-selectors.js
@@ -126,7 +126,7 @@ const getChartTypeSelected = createSelector(
   [ getChartTypeOptions, getChartTypeSelection ],
   (chartTypeOptions, chartTypeSelected) => {
     if (!chartTypeOptions) return null;
-    if (!chartTypeSelected) return chartTypeOptions[0];
+    if (!chartTypeSelected) return chartTypeOptions[1];
     return chartTypeOptions.find(s => s.value === chartTypeSelected);
   }
 );

--- a/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-styles.scss
+++ b/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-styles.scss
@@ -21,7 +21,6 @@
 .cardsContainer {
   display: flex;
   flex-wrap: nowrap;
-  overflow: scroll;
   margin-bottom: 0;
 
   > div {


### PR DESCRIPTION
This PR collects fixes for [units in per capita](https://basecamp.com/1756858/projects/13795275/todos/373511065), [landing page unit](https://basecamp.com/1756858/projects/13795275/todos/373239987), [landing page data issue](https://basecamp.com/1756858/projects/13795275/todos/373528594), [remove 'm' suffix](https://basecamp.com/1756858/projects/13795275/todos/373303427) and [uppercase GHG column title](https://basecamp.com/1756858/projects/13795275/todos/373526344)

**Landing page:**
- Fix data selectors in Historical emissions; before source of the data was incorrect, now the data presented in chart is total data from only 4 sectors, according to the chart description:  _South Africa’s National GHG inventory for the period 2000-2014 was compiled according to the IPCC-2006 guidelines and covers four emission sectors:_ **Energy**; **Industrial Processes and Product Use**; **Agriculture, Forestry and Other Land Use;** _and_ **Waste**.):
Should I use here data from other sectors or subsectors?
**Btw.** in the description above we have _South Africa’s National GHG inventory for the period 2000-2014_ but  data is from 2000 to 2012, is it correct?
- The unit is now in MtCO2e, but only in `absolute`; in `per capita` and `per GDP` unit is CO2e because values there are really small. That is why I added also `scale` and `format` props to the component.

**GHG Emissions page:**
- The unit is now in MtCO2e, like in landing page, also in `per capita` and `per GDP` unit is CO2e, added  `scale` and `format` props.

**Financial resources page**
- Remove suffix `m` and add space between focus elements in tooltip:
![screenshot from 2018-12-11 11-53-08](https://user-images.githubusercontent.com/15097138/49798959-8de08700-fd3b-11e8-9033-1a36f1637a43.png)
- To keep consistency I also removed suffix `m` from Bubble chart

**Mitigation Actions page**
- Uppercase for GHG column:
![screenshot from 2018-12-11 12-13-10](https://user-images.githubusercontent.com/15097138/49800012-617a3a00-fd3e-11e8-9a50-66d638a083eb.png)
