### PR TITLE
Make Total including FOLU sector the first one on the list

### DIFF
--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -19,6 +19,7 @@ const { COUNTRY_ISO } = process.env;
 const defaults = { gas: 'All GHG', source: 'DEA2017b' };
 const excludedSectors = [ 'Total excluding FOLU' ];
 const excludedGases = [ 'TotalGHG' ];
+const includingSector = 'Total including FOLU';
 
 const getMetaData = ({ metadata = {} }) =>
   metadata.ghg ? metadata.ghg.data : null;
@@ -107,6 +108,12 @@ export const getSectorOptions = createSelector(
         groupParent: String(d.value)
       }));
 
+    const lastShowingSectors = sectors.filter(s => s.label !== includingSector);
+    const firstShowingSectors = sectors.filter(
+      s => s.label === includingSector
+    );
+    const parsedSectors = [ ...firstShowingSectors, ...lastShowingSectors ];
+
     const subsectors = meta.sector
       .filter(
         s =>
@@ -119,7 +126,7 @@ export const getSectorOptions = createSelector(
         value: d.value,
         group: String(d.parentId)
       }));
-    return [ ...sectors, ...subsectors ];
+    return [ ...parsedSectors, ...subsectors ];
   }
 );
 


### PR DESCRIPTION
Move `Total including FOLU` sector in GHG emissions / historical emissions to the top of the dropdown.

![screenshot 2018-12-12 at 17 55 37](https://user-images.githubusercontent.com/6136899/49885340-40494480-fe37-11e8-974a-456a77024cbc.png)
