### PR TITLE
Fix data downloads

### DIFF
--- a/app/controllers/api/v1/financial_resource/received_supports_controller.rb
+++ b/app/controllers/api/v1/financial_resource/received_supports_controller.rb
@@ -8,7 +8,7 @@ module Api
           respond_to do |format|
             format.json do
               render json: values,
-                     each_serializer: Api::V1::FinancialResource::ReceivedSupportSerializer,
+                     each_serializer: ReceivedSupportSerializer,
                      meta: ::FinancialResource::Indicator.all.
                        as_json(except: [:id, :created_at, :updated_at])
             end
@@ -17,8 +17,7 @@ module Api
               data_sources = data_sources.where(short_title: sources) if sources
 
               render zip: {
-                'received_supports.csv' =>
-                  Api::V1::FinancialResource::ReceivedSupportCSVSerializer.new(values).to_csv,
+                'received_supports.csv' => ReceivedSupportCSVSerializer.new(values).to_csv,
                 'data_sources.csv' => data_sources.to_csv
               }
             end

--- a/app/controllers/api/v1/financial_resource/received_supports_controller.rb
+++ b/app/controllers/api/v1/financial_resource/received_supports_controller.rb
@@ -3,7 +3,7 @@ module Api
     module FinancialResource
       class ReceivedSupportsController < ApiController
         def index
-          values = ::FinancialResource::ReceivedSupport.all
+          values = ::FinancialResource::ReceivedSupport.includes(:donor)
 
           respond_to do |format|
             format.json do
@@ -12,13 +12,23 @@ module Api
                      meta: ::FinancialResource::Indicator.all.
                        as_json(except: [:id, :created_at, :updated_at])
             end
-            format.csv do
-              send_data values.to_csv,
-                        type: 'text/csv',
-                        filename: 'received_supports.csv',
-                        disposition: 'attachment'
+            format.zip do
+              data_sources = DataSource.all
+              data_sources = data_sources.where(short_title: sources) if sources
+
+              render zip: {
+                'received_supports.csv' =>
+                  Api::V1::FinancialResource::ReceivedSupportCSVSerializer.new(values).to_csv,
+                'data_sources.csv' => data_sources.to_csv
+              }
             end
           end
+        end
+
+        private
+
+        def sources
+          params[:sources].presence && params[:sources].split(',')
         end
       end
     end

--- a/app/controllers/api/v1/financial_resource/support_needs_controller.rb
+++ b/app/controllers/api/v1/financial_resource/support_needs_controller.rb
@@ -8,7 +8,7 @@ module Api
           respond_to do |format|
             format.json do
               render json: values,
-                     each_serializer: Api::V1::FinancialResource::SupportNeedSerializer,
+                     each_serializer: SupportNeedSerializer,
                      meta: ::FinancialResource::Indicator.all.
                        as_json(except: [:id, :created_at, :updated_at])
             end

--- a/app/controllers/api/v1/financial_resource/support_needs_controller.rb
+++ b/app/controllers/api/v1/financial_resource/support_needs_controller.rb
@@ -12,13 +12,22 @@ module Api
                      meta: ::FinancialResource::Indicator.all.
                        as_json(except: [:id, :created_at, :updated_at])
             end
-            format.csv do
-              send_data values.to_csv,
-                        type: 'text/csv',
-                        filename: 'support_needs.csv',
-                        disposition: 'attachment'
+            format.zip do
+              data_sources = DataSource.all
+              data_sources = data_sources.where(short_title: sources) if sources
+
+              render zip: {
+                'support_needs.csv' => values.to_csv,
+                'data_sources.csv' => data_sources.to_csv
+              }
             end
           end
+        end
+
+        private
+
+        def sources
+          params[:sources].presence && params[:sources].split(',')
         end
       end
     end

--- a/app/controllers/api/v1/ghg/projected_emissions_controller.rb
+++ b/app/controllers/api/v1/ghg/projected_emissions_controller.rb
@@ -3,20 +3,31 @@ module Api
     module Ghg
       class ProjectedEmissionsController < ApiController
         def index
-          values = ::Ghg::ProjectedEmission.all
+          values = ::Ghg::ProjectedEmission.includes(:projected_emission_years)
           metadata = ::Ghg::ProjectedEmissionMetadata.all
 
           respond_to do |format|
             format.json do
               render json: ProjectedEmissionSerializer.new(values, metadata).to_json
             end
-            format.csv do
-              send_data values.to_csv,
-                        type: 'text/csv',
-                        filename: 'projected_emissions.csv',
-                        disposition: 'attachment'
+            format.zip do
+              data_sources = DataSource.all
+              data_sources = data_sources.where(short_title: sources) if sources
+
+              render zip: {
+                'projected_emissions.csv' =>
+                  ProjectedEmissionCSVSerializer.new(values).to_csv,
+                'indicators.csv' => metadata.to_csv,
+                'data_sources.csv' => data_sources.to_csv
+              }
             end
           end
+        end
+
+        private
+
+        def sources
+          params[:sources].presence && params[:sources].split(',')
         end
       end
     end

--- a/app/controllers/api/v1/inventory_improvement_projects_controller.rb
+++ b/app/controllers/api/v1/inventory_improvement_projects_controller.rb
@@ -9,13 +9,22 @@ module Api
             render json: projects,
                    each_serializer: Api::V1::InventoryImprovement::ProjectSerializer
           end
-          format.csv do
-            send_data projects.to_csv,
-                      type: 'text/csv',
-                      filename: 'inventory_improvement_projects.csv',
-                      disposition: 'attachment'
+          format.zip do
+            data_sources = DataSource.all
+            data_sources = data_sources.where(short_title: sources) if sources
+
+            render zip: {
+              'inventory_improvement_projects.csv' => projects.to_csv,
+              'data_sources.csv' => data_sources.to_csv
+            }
           end
         end
+      end
+
+      private
+
+      def sources
+        params[:sources].presence && params[:sources].split(',')
       end
     end
   end

--- a/app/controllers/api/v1/mitigation/mitigation_actions_controller.rb
+++ b/app/controllers/api/v1/mitigation/mitigation_actions_controller.rb
@@ -3,20 +3,30 @@ module Api
     module Mitigation
       class MitigationActionsController < ApiController
         def index
-          values = ::Mitigation::MitigationAction.all
+          values = ::Mitigation::MitigationAction.includes(mitigation_theme: [:mitigation_sector])
 
           respond_to do |format|
             format.json do
               render json: values,
                      each_serializer: Api::V1::Mitigation::MitigationActionSerializer
             end
-            format.csv do
-              send_data values.to_csv,
-                        type: 'text/csv',
-                        filename: 'mitigation_actions.csv',
-                        disposition: 'attachment'
+            format.zip do
+              data_sources = DataSource.all
+              data_sources = data_sources.where(short_title: sources) if sources
+
+              render zip: {
+                'mitigation_actions.csv' =>
+                  Api::V1::Mitigation::MitigationActionCSVSerializer.new(values).to_csv,
+                'data_sources.csv' => data_sources.to_csv
+              }
             end
           end
+        end
+
+        private
+
+        def sources
+          params[:sources].presence && params[:sources].split(',')
         end
       end
     end

--- a/app/controllers/api/v1/mitigation/mitigation_actions_controller.rb
+++ b/app/controllers/api/v1/mitigation/mitigation_actions_controller.rb
@@ -8,15 +8,14 @@ module Api
           respond_to do |format|
             format.json do
               render json: values,
-                     each_serializer: Api::V1::Mitigation::MitigationActionSerializer
+                     each_serializer: MitigationActionSerializer
             end
             format.zip do
               data_sources = DataSource.all
               data_sources = data_sources.where(short_title: sources) if sources
 
               render zip: {
-                'mitigation_actions.csv' =>
-                  Api::V1::Mitigation::MitigationActionCSVSerializer.new(values).to_csv,
+                'mitigation_actions.csv' => MitigationActionCSVSerializer.new(values).to_csv,
                 'data_sources.csv' => data_sources.to_csv
               }
             end

--- a/app/controllers/api/v1/mitigation/mitigation_effects_controller.rb
+++ b/app/controllers/api/v1/mitigation/mitigation_effects_controller.rb
@@ -12,13 +12,22 @@ module Api
                      meta: ::Mitigation::MitigationIndicator.all.
                        select(:code, :indicator, :unit, :cautions)
             end
-            format.csv do
-              send_data values.to_csv,
-                        type: 'text/csv',
-                        filename: 'mitigation_effects.csv',
-                        disposition: 'attachment'
+            format.zip do
+              data_sources = DataSource.all
+              data_sources = data_sources.where(short_title: sources) if sources
+
+              render zip: {
+                'mitigation_effects.csv' => values.to_csv,
+                'data_sources.csv' => data_sources.to_csv
+              }
             end
           end
+        end
+
+        private
+
+        def sources
+          params[:sources].presence && params[:sources].split(',')
         end
       end
     end

--- a/app/controllers/api/v1/mitigation/mitigation_effects_controller.rb
+++ b/app/controllers/api/v1/mitigation/mitigation_effects_controller.rb
@@ -8,7 +8,7 @@ module Api
           respond_to do |format|
             format.json do
               render json: values,
-                     each_serializer: Api::V1::Mitigation::MitigationEffectSerializer,
+                     each_serializer: MitigationEffectSerializer,
                      meta: ::Mitigation::MitigationIndicator.all.
                        select(:code, :indicator, :unit, :cautions)
             end

--- a/app/controllers/api/v1/national_circumstance/categories_controller.rb
+++ b/app/controllers/api/v1/national_circumstance/categories_controller.rb
@@ -3,7 +3,9 @@ module Api
     module NationalCircumstance
       class CategoriesController < ApiController
         def index
-          values = ::NationalCircumstance::Category.all
+          values = ::NationalCircumstance::Category.
+            includes(:location, :category_group, :category_years)
+          values = values.where(nc_category_groups: {name: group}) if group
 
           respond_to do |format|
             format.json do
@@ -12,13 +14,26 @@ module Api
                      meta: ::NationalCircumstance::Indicator.all.
                        as_json(except: %w[id created_at updated_at])
             end
-            format.csv do
-              send_data values.to_csv,
-                        type: 'text/csv',
-                        filename: 'categories.csv',
-                        disposition: 'attachment'
+            format.zip do
+              data_sources = DataSource.all
+              data_sources = data_sources.where(short_title: sources) if sources
+
+              render zip: {
+                'values.csv' => Api::V1::NationalCircumstance::CategoryCSVSerializer.new(values).to_csv,
+                'data_sources.csv' => data_sources.to_csv
+              }, filename: group || 'categories'
             end
           end
+        end
+
+        private
+
+        def group
+          params[:group]
+        end
+
+        def sources
+          params[:sources].presence && params[:sources].split(',')
         end
       end
     end

--- a/app/controllers/api/v1/national_circumstance/categories_controller.rb
+++ b/app/controllers/api/v1/national_circumstance/categories_controller.rb
@@ -10,7 +10,7 @@ module Api
           respond_to do |format|
             format.json do
               render json: values,
-                     each_serializer: Api::V1::NationalCircumstance::CategorySerializer,
+                     each_serializer: CategorySerializer,
                      meta: ::NationalCircumstance::Indicator.all.
                        as_json(except: %w[id created_at updated_at])
             end
@@ -19,7 +19,7 @@ module Api
               data_sources = data_sources.where(short_title: sources) if sources
 
               render zip: {
-                'values.csv' => Api::V1::NationalCircumstance::CategoryCSVSerializer.new(values).to_csv,
+                'values.csv' => CategoryCSVSerializer.new(values).to_csv,
                 'data_sources.csv' => data_sources.to_csv
               }, filename: group || 'categories'
             end

--- a/app/controllers/api/v1/national_circumstance/priorities_controller.rb
+++ b/app/controllers/api/v1/national_circumstance/priorities_controller.rb
@@ -9,7 +9,7 @@ module Api
           respond_to do |format|
             format.json do
               render json: values,
-                     each_serializer: Api::V1::NationalCircumstance::PrioritySerializer,
+                     each_serializer: PrioritySerializer,
                      meta: ::NationalCircumstance::Indicator.all.
                        as_json(except: %w[id created_at updated_at])
             end
@@ -18,7 +18,7 @@ module Api
               data_sources = data_sources.where(short_title: sources) if sources
 
               render zip: {
-                'priorities.csv' => Api::V1::NationalCircumstance::PriorityCSVSerializer.new(values).to_csv,
+                'priorities.csv' => PriorityCSVSerializer.new(values).to_csv,
                 'data_sources.csv' => data_sources.to_csv
               }
             end

--- a/app/controllers/api/v1/national_circumstance/priorities_controller.rb
+++ b/app/controllers/api/v1/national_circumstance/priorities_controller.rb
@@ -3,7 +3,8 @@ module Api
     module NationalCircumstance
       class PrioritiesController < ApiController
         def index
-          values = ::NationalCircumstance::Priority.all
+          values = ::NationalCircumstance::Priority.includes(:location)
+          values = values.where(code: codes) if codes
 
           respond_to do |format|
             format.json do
@@ -12,13 +13,30 @@ module Api
                      meta: ::NationalCircumstance::Indicator.all.
                        as_json(except: %w[id created_at updated_at])
             end
-            format.csv do
-              send_data values.to_csv,
-                        type: 'text/csv',
-                        filename: 'priorities.csv',
-                        disposition: 'attachment'
+            format.zip do
+              data_sources = DataSource.all
+              data_sources = data_sources.where(short_title: sources) if sources
+
+              render zip: {
+                'priorities.csv' => Api::V1::NationalCircumstance::PriorityCSVSerializer.new(values).to_csv,
+                'data_sources.csv' => data_sources.to_csv
+              }
             end
           end
+        end
+
+        private
+
+        def codes
+          return unless sources
+
+          sources.map do |source|
+            ::NationalCircumstance::Priority::DATA_SOURCE_TO_CODES_MAP[source]
+          end.flatten
+        end
+
+        def sources
+          params[:sources].presence && params[:sources].split(',')
         end
       end
     end

--- a/app/decorators/controllers/historical_emissions/historical_emissions_controller_decorator.rb
+++ b/app/decorators/controllers/historical_emissions/historical_emissions_controller_decorator.rb
@@ -13,6 +13,17 @@ HistoricalEmissions::HistoricalEmissionsController.class_eval do
     end
   end
 
+  def download
+    data_sources = DataSource.where(short_title: 'DEA2017b')
+    filter = HistoricalEmissions::Filter.new({})
+    csv_content = HistoricalEmissions::CsvContent.new(filter).call
+
+    render zip: {
+      'historical_emissions.csv' => csv_content,
+      'data_sources.csv' => data_sources.to_csv
+    }
+  end
+
   def meta
     render(
       json: HistoricalEmissionsMetadata.new(

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-component.jsx
@@ -25,7 +25,6 @@ class TotalGhgEmissions extends PureComponent {
       metricOptions,
       emissionsParams,
       chartData,
-      downloadUri,
       contentData
     } = this.props;
     const scale = has(chartData, 'config.axes.yLeft.scale')
@@ -55,7 +54,7 @@ class TotalGhgEmissions extends PureComponent {
         </Button>
         <InfoDownloadToolbox
           slugs="DEA2017b"
-          downloadUri={downloadUri}
+          downloadUri="emissions/download"
           className={styles.buttonWrapper}
         />
       </div>
@@ -111,7 +110,6 @@ TotalGhgEmissions.propTypes = {
   metricSelected: PropTypes.object,
   emissionsParams: PropTypes.object,
   updateMetricSelected: PropTypes.func.isRequired,
-  downloadUri: PropTypes.string,
   contentData: PropTypes.shape({
     title: PropTypes.string,
     description: PropTypes.string
@@ -122,7 +120,6 @@ TotalGhgEmissions.defaultProps = {
   metricOptions: [],
   metricSelected: null,
   emissionsParams: null,
-  downloadUri: null,
   contentData: {}
 };
 export default TotalGhgEmissions;

--- a/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
+++ b/app/javascript/app/components/home/total-ghg-emissions/total-ghg-emissions-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector, createStructuredSelector } from 'reselect';
-import { flatten, sumBy, groupBy, isEmpty, uniqBy, has } from 'lodash';
+import { flatten, sumBy, groupBy, isEmpty, uniqBy } from 'lodash';
 import { METRIC_OPTIONS } from 'utils/defaults';
 import {
   DEFAULT_AXES_CONFIG,
@@ -63,15 +63,6 @@ const getSector = createSelector(getMetaData, meta => {
   const selected = meta.sector.find(source => source.label === defaults.sector);
   return selected && selected.value || null;
 });
-
-const getDownloadUri = ({ metadata = {} }) => {
-  const dataSources = has(metadata, 'ghg.data.dataSource') &&
-    metadata.ghg.data.dataSource;
-  const dataSource = dataSources &&
-    dataSources.find(d => d.source === 'DEA2017b');
-  const id = dataSource && dataSource.value;
-  return id ? `emissions.csv?source=${id}&location=ZAF` : null;
-};
 
 export const getEmissionsParams = createSelector(
   [ getSource, getGas, getSector ],
@@ -198,6 +189,5 @@ export const getTotalGHGEMissions = createStructuredSelector({
   metricSelected: getMetricSelected,
   emissionsParams: getEmissionsParams,
   chartData: getChartData,
-  contentData: getTitleAndDescription,
-  downloadUri: getDownloadUri
+  contentData: getTitleAndDescription
 });

--- a/app/javascript/app/components/info-download-toolbox/info-download-toolbox-component.jsx
+++ b/app/javascript/app/components/info-download-toolbox/info-download-toolbox-component.jsx
@@ -14,7 +14,7 @@ const { API_URL } = process.env;
 class InfoDownloadToolbox extends PureComponent {
   handleDownloadClick = () => {
     const { downloadUri } = this.props;
-    if (downloadUri) window.open(`${API_URL}/${downloadUri}.csv`, '_blank');
+    if (downloadUri) window.open(`${API_URL}/${downloadUri}`, '_blank');
   };
 
   handleInfoClick = () => {
@@ -36,7 +36,7 @@ class InfoDownloadToolbox extends PureComponent {
           )
         }}
       >
-        <div data-for="blueTooltip" data-tip="Chart information">
+        <div data-for="blueTooltip" data-tip="Data information">
           <Button
             onClick={this.handleInfoClick}
             theme={{
@@ -46,7 +46,7 @@ class InfoDownloadToolbox extends PureComponent {
             <Icon icon={iconInfo} />
           </Button>
         </div>
-        <div data-for="blueTooltip" data-tip="Download chart in .csv">
+        <div data-for="blueTooltip" data-tip="Download data in .csv">
           {
             !noDownload && (
             <Button

--- a/app/javascript/app/pages/financial-resources/support-needed/support-needed-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-needed/support-needed-component.jsx
@@ -52,7 +52,7 @@ class SupportNeeded extends PureComponent {
           onFilterChange={this.handleFilterChange}
           activeTabValue={activeTabValue}
           slugs="BUR2"
-          downloadUri="financial_resource/support_needs"
+          downloadUri="financial_resource/support_needs.zip?sources=BUR2"
         />
         <FinancialResourcesNeededProvider />
       </div>

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
@@ -95,7 +95,7 @@ class SupportReceived extends PureComponent {
           onTabChange={this.handleTabChange}
           onFilterChange={this.handleFilterChange}
           activeTabValue={activeTabValue}
-          downloadUri="financial_resource/received_supports"
+          downloadUri="financial_resource/received_supports.csv"
           slugs="BUR2"
         />
         <FinancialResourcesReceivedProvider />

--- a/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
+++ b/app/javascript/app/pages/financial-resources/support-received/support-received-component.jsx
@@ -95,7 +95,7 @@ class SupportReceived extends PureComponent {
           onTabChange={this.handleTabChange}
           onFilterChange={this.handleFilterChange}
           activeTabValue={activeTabValue}
-          downloadUri="financial_resource/received_supports.csv"
+          downloadUri="financial_resource/received_supports.zip?sources=BUR2"
           slugs="BUR2"
         />
         <FinancialResourcesReceivedProvider />

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-component.jsx
@@ -89,7 +89,6 @@ class GHGHistoricalEmissions extends PureComponent {
       metricOptions,
       emissionsParams,
       chartData,
-      downloadUri,
       title,
       description
     } = this.props;
@@ -131,7 +130,7 @@ class GHGHistoricalEmissions extends PureComponent {
       <div className={styles.toolbarButtons}>
         <InfoDownloadToolbox
           slugs="DEA2017b"
-          downloadUri={downloadUri}
+          downloadUri="emissions/download"
           className={styles.buttonWrapper}
         />
       </div>
@@ -197,7 +196,6 @@ GHGHistoricalEmissions.propTypes = {
   emissionsParams: PropTypes.object,
   onFilterChange: PropTypes.func.isRequired,
   updateFiltersSelected: PropTypes.func.isRequired,
-  downloadUri: PropTypes.string,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired
 };
@@ -209,7 +207,6 @@ GHGHistoricalEmissions.defaultProps = {
   gasSelected: null,
   metricOptions: [],
   metricSelected: null,
-  emissionsParams: null,
-  downloadUri: null
+  emissionsParams: null
 };
 export default GHGHistoricalEmissions;

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -2,7 +2,6 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import groupBy from 'lodash/groupBy';
 import uniq from 'lodash/uniq';
-import has from 'lodash/has';
 import intersection from 'lodash/intersection';
 import { METRIC_OPTIONS } from 'utils/defaults';
 import {
@@ -35,15 +34,6 @@ const getEmissionsData = ({ GHGEmissions = {} }) =>
 
 const getChartLoading = ({ metadata = {}, GHGEmissions = {} }) =>
   metadata.ghg.loading || GHGEmissions.loading;
-
-const getDownloadUri = ({ metadata = {} }) => {
-  const dataSources = has(metadata, 'ghg.data.dataSource') &&
-    metadata.ghg.data.dataSource;
-  const dataSource = dataSources &&
-    dataSources.find(d => d.source === 'DEA2017b');
-  const id = dataSource && dataSource.value;
-  return id ? `emissions.csv?source=${id}&location=ZAF` : null;
-};
 
 const getSource = createSelector(getMetaData, meta => {
   if (!meta || !meta.dataSource) return null;
@@ -301,6 +291,5 @@ export const getTotalGHGEMissions = createStructuredSelector({
   metricSelected: getMetricSelected,
   emissionsParams: getEmissionsParams,
   chartData: getChartData,
-  query: getQueryParams,
-  downloadUri: getDownloadUri
+  query: getQueryParams
 });

--- a/app/javascript/app/pages/ghg-emissions/inventory/inventory-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/inventory/inventory-component.jsx
@@ -65,7 +65,7 @@ class GHGInventory extends PureComponent {
           searchFilter={searchFilter}
           onFilterChange={this.handleFilterChange}
           activeTabValue={activeTabValue}
-          downloadUri="inventory_improvement_projects.csv"
+          downloadUri="inventory_improvement_projects.zip?sources=BUR2"
           slugs="BUR2"
         />
         <GHGInventoryProvider />

--- a/app/javascript/app/pages/ghg-emissions/inventory/inventory-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/inventory/inventory-component.jsx
@@ -65,7 +65,7 @@ class GHGInventory extends PureComponent {
           searchFilter={searchFilter}
           onFilterChange={this.handleFilterChange}
           activeTabValue={activeTabValue}
-          downloadUri="inventory_improvement_projects"
+          downloadUri="inventory_improvement_projects.csv"
           slugs="BUR2"
         />
         <GHGInventoryProvider />

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
@@ -121,7 +121,7 @@ class ProjectedEmissions extends PureComponent {
           />
           <InfoDownloadToolbox
             slugs="DEA2016e"
-            downloadUri="ghg/projected_emissions.csv"
+            downloadUri="ghg/projected_emissions.zip?sources=DEA2016e"
           />
         </div>
         <p

--- a/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
+++ b/app/javascript/app/pages/ghg-emissions/projected-emissions/projected-emissions-component.jsx
@@ -121,7 +121,7 @@ class ProjectedEmissions extends PureComponent {
           />
           <InfoDownloadToolbox
             slugs="DEA2016e"
-            downloadUri="ghg/projected_emissions"
+            downloadUri="ghg/projected_emissions.csv"
           />
         </div>
         <p

--- a/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-component.jsx
@@ -48,7 +48,7 @@ class MitigationActions extends PureComponent {
           onTabChange={this.handleTabChange}
           onFilterChange={this.handleFilterChange}
           activeTabValue={activeTabValue}
-          downloadUri="mitigation/mitigation_actions.csv"
+          downloadUri="mitigation/mitigation_actions.zip?sources=BUR2"
           slugs="BUR2"
         />
         <MitigationActionsProvider />

--- a/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-actions/mitigation-actions-component.jsx
@@ -48,7 +48,7 @@ class MitigationActions extends PureComponent {
           onTabChange={this.handleTabChange}
           onFilterChange={this.handleFilterChange}
           activeTabValue={activeTabValue}
-          downloadUri="mitigation/mitigation_actions"
+          downloadUri="mitigation/mitigation_actions.csv"
           slugs="BUR2"
         />
         <MitigationActionsProvider />

--- a/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-component.jsx
@@ -90,7 +90,7 @@ class Summary extends PureComponent {
             <InfoDownloadToolbox
               slugs="BUR2"
               className={styles.buttonWrapper}
-              downloadUri="mitigation/mitigation_effects"
+              downloadUri="mitigation/mitigation_effects.csv"
             />
           </div>
         </div>

--- a/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-component.jsx
@@ -90,7 +90,7 @@ class Summary extends PureComponent {
             <InfoDownloadToolbox
               slugs="BUR2"
               className={styles.buttonWrapper}
-              downloadUri="mitigation/mitigation_effects.csv"
+              downloadUri="mitigation/mitigation_effects.zip?sources=BUR2"
             />
           </div>
         </div>

--- a/app/javascript/app/pages/national-circumstances/economy/economy-constants.js
+++ b/app/javascript/app/pages/national-circumstances/economy/economy-constants.js
@@ -1,0 +1,1 @@
+export const DOWNLOAD_URI = 'national_circumstance/categories.zip?sources=UNDP2018,STAT2014b&group=economy';

--- a/app/javascript/app/pages/national-circumstances/economy/gdp-growth/gdp-growth-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/economy/gdp-growth/gdp-growth-component.jsx
@@ -5,6 +5,9 @@ import { ChartComposed } from 'cw-components';
 import { Area, Line } from 'recharts';
 import MetaProvider from 'providers/metadata-provider';
 import NationalCircumstancesProvider from 'providers/national-circumstances-provider';
+import {
+  DOWNLOAD_URI
+} from 'pages/national-circumstances/economy/economy-constants';
 import { CustomYAxisTick } from './axis-ticks';
 import GdpTooltip from './gdp-tooltip-chart';
 
@@ -43,10 +46,7 @@ class GDPGrowth extends PureComponent {
     return (
       <React.Fragment>
         <div className={styles.toolbar}>
-          <InfoDownloadToolbox
-            slugs="STAT2014b"
-            downloadUri="national_circumstance/categories"
-          />
+          <InfoDownloadToolbox slugs="STAT2014b" downloadUri={DOWNLOAD_URI} />
         </div>
         <div className={styles.chart}>
           {

--- a/app/javascript/app/pages/national-circumstances/economy/gdp/gdp-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/economy/gdp/gdp-component.jsx
@@ -6,6 +6,9 @@ import { Dropdown, Chart } from 'cw-components';
 import MetaProvider from 'providers/metadata-provider';
 import NationalCircumstancesProvider from 'providers/national-circumstances-provider';
 import WorldBankProvider from 'providers/world-bank-provider';
+import {
+  DOWNLOAD_URI
+} from 'pages/national-circumstances/economy/economy-constants';
 import { CustomYAxisTick } from './axis-ticks';
 import CustomTooltip from './gdp-tooltip';
 
@@ -32,10 +35,7 @@ class GDP extends PureComponent {
       />
     );
     const toolbar = (
-      <InfoDownloadToolbox
-        slugs="STAT2014b"
-        downloadUri="national_circumstance/categories"
-      />
+      <InfoDownloadToolbox slugs="STAT2014b" downloadUri={DOWNLOAD_URI} />
     );
     return (
       <React.Fragment>

--- a/app/javascript/app/pages/national-circumstances/economy/human-development-index/human-development-index-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/economy/human-development-index/human-development-index-component.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import InfoDownloadToolbox from 'components/info-download-toolbox';
 import { Chart } from 'cw-components';
 import NationalCircumstancesProvider from 'providers/national-circumstances-provider';
+import {
+  DOWNLOAD_URI
+} from 'pages/national-circumstances/economy/economy-constants';
 import { CustomYAxisTick } from './axis-ticks';
 import HdiTooltip from './hdi-tooltip-chart';
 
@@ -18,10 +21,7 @@ class HumanDevelopmentIndex extends PureComponent {
     return (
       <React.Fragment>
         <div className={styles.toolbar}>
-          <InfoDownloadToolbox
-            slugs="UNDP2015"
-            downloadUri="national_circumstance/categories"
-          />
+          <InfoDownloadToolbox slugs="UNDP2018" downloadUri={DOWNLOAD_URI} />
         </div>
         <div className={styles.chart}>
           {

--- a/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/energy/energy-component.jsx
@@ -61,7 +61,7 @@ class Energy extends PureComponent {
       <div className={styles.toolbarButtons}>
         <InfoDownloadToolbox
           slugs="DOE2016b"
-          downloadUri="national_circumstance/categories"
+          downloadUri="national_circumstance/categories.zip?sources=DOE2016b&amp;group=energy"
           className={styles.buttonWrapper}
         />
       </div>

--- a/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/natural-disasters/natural-disasters-component.jsx
@@ -20,7 +20,7 @@ class NaturalDisasters extends PureComponent {
           <div className={styles.buttonWrapper}>
             <InfoDownloadToolbox
               slugs="COGTA2015"
-              downloadUri="national_circumstance/categories"
+              downloadUri="national_circumstance/priorities.zip?sources=COGTA2015"
             />
           </div>
         </div>

--- a/app/javascript/app/pages/national-circumstances/population/distribution-by-age/distribution-by-age-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/population/distribution-by-age/distribution-by-age-component.jsx
@@ -33,7 +33,7 @@ class PopulationTab extends PureComponent {
     const toolbar = (
       <InfoDownloadToolbox
         slugs="STAT2014a"
-        downloadUri="national_circumstance/categories"
+        downloadUri="national_circumstance/categories.zip?group=population&amp;sources=STAT2014a"
       />
     );
 

--- a/app/javascript/app/pages/national-circumstances/population/population-tab/population-tab-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/population/population-tab/population-tab-component.jsx
@@ -42,7 +42,7 @@ class PopulationTab extends PureComponent {
     const toolbar = (
       <InfoDownloadToolbox
         slugs="STAT2014a"
-        downloadUri="national_circumstance/categories.zip?sources=STAT2014a"
+        downloadUri="national_circumstance/categories.zip?group=population&amp;sources=STAT2014a"
       />
     );
     return (

--- a/app/javascript/app/pages/national-circumstances/population/population-tab/population-tab-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/population/population-tab/population-tab-component.jsx
@@ -42,7 +42,7 @@ class PopulationTab extends PureComponent {
     const toolbar = (
       <InfoDownloadToolbox
         slugs="STAT2014a"
-        downloadUri="national_circumstance/categories"
+        downloadUri="national_circumstance/categories.zip?sources=STAT2014a"
       />
     );
     return (

--- a/app/javascript/app/pages/national-circumstances/provincial/provincial-component.jsx
+++ b/app/javascript/app/pages/national-circumstances/provincial/provincial-component.jsx
@@ -39,7 +39,7 @@ class Provincial extends PureComponent {
           onFilterChange={this.handleFilterChange}
           activeTabValue={activeTabValue}
           slugs="BUR2"
-          downloadUri="national_circumstance/priorities"
+          downloadUri="national_circumstance/priorities.zip?sources=BUR2"
         />
         <NationalCircumstancesPrioritiesProvider />
       </div>

--- a/app/models/national_circumstance/priority.rb
+++ b/app/models/national_circumstance/priority.rb
@@ -14,6 +14,14 @@ module NationalCircumstance
   class Priority < ApplicationRecord
     include ::GenericToCsv
 
+    DEV_PRIORITIES_CODES = %w(Dev_priorities_mitigation Dev_priorities_adaptation).freeze
+    NATURAL_DISASTERS_CODES = %w(Flood_damage Drough_damage Fire_damage).freeze
+
+    DATA_SOURCE_TO_CODES_MAP = {
+      'COGTA2015' => %w(Flood_damage Drough_damage Fire_damage),
+      'BUR2' => %w(Dev_priorities_mitigation Dev_priorities_adaptation)
+    }.freeze
+
     validates_presence_of :value, :code
     belongs_to :location
   end

--- a/app/serializers/api/v1/financial_resource/received_support_csv_serializer.rb
+++ b/app/serializers/api/v1/financial_resource/received_support_csv_serializer.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    module FinancialResource
+      class ReceivedSupportCSVSerializer < ApplicationSerializer
+        def initialize(values)
+          @values = Array.wrap(values)
+        end
+
+        def to_csv
+          attribute_names = ::FinancialResource::ReceivedSupport.column_names - %w(id donor_id created_at updated_at)
+          headers = (['donor'] + attribute_names).map(&:humanize)
+
+          CSV.generate do |csv|
+            csv << headers
+
+            @values.each do |value|
+              csv << [
+                value.donor.name,
+                attribute_names.map { |attr_name| value.attributes[attr_name] }
+              ].flatten
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/financial_resource/received_support_csv_serializer.rb
+++ b/app/serializers/api/v1/financial_resource/received_support_csv_serializer.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     module FinancialResource
-      class ReceivedSupportCSVSerializer < ApplicationSerializer
+      class ReceivedSupportCSVSerializer
         def initialize(values)
           @values = Array.wrap(values)
         end

--- a/app/serializers/api/v1/ghg/projected_emission_csv_serializer.rb
+++ b/app/serializers/api/v1/ghg/projected_emission_csv_serializer.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    module Ghg
+      class ProjectedEmissionCSVSerializer
+        def initialize(values)
+          @values = Array.wrap(values)
+        end
+
+        def to_csv
+          year_columns = @values.flat_map(&:projected_emission_years).map(&:year).uniq.sort
+
+          headers = %w(indicator_code boundary) + year_columns
+
+          CSV.generate do |csv|
+            csv << headers
+
+            @values.each do |value|
+              csv << [
+                value.name,
+                value.boundary,
+                year_columns.map do |year|
+                  value.projected_emission_years.select { |pey| pey.year == year }.map(&:value)
+                end
+              ].flatten
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/mitigation/mitigation_action_csv_serializer.rb
+++ b/app/serializers/api/v1/mitigation/mitigation_action_csv_serializer.rb
@@ -1,0 +1,29 @@
+module Api
+  module V1
+    module Mitigation
+      class MitigationActionCSVSerializer
+        def initialize(values)
+          @values = Array.wrap(values)
+        end
+
+        def to_csv
+          excluded_attributes = %w(id mitigation_theme_id created_at updated_at)
+          attribute_names = ::Mitigation::MitigationAction.column_names - excluded_attributes
+          headers = (%w(theme sector) + attribute_names).map(&:humanize)
+
+          CSV.generate do |csv|
+            csv << headers
+
+            @values.each do |value|
+              csv << [
+                value.mitigation_theme.title,
+                value.mitigation_theme.mitigation_sector.name,
+                attribute_names.map { |attr_name| value.attributes[attr_name] }
+              ].flatten
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/national_circumstance/category_csv_serializer.rb
+++ b/app/serializers/api/v1/national_circumstance/category_csv_serializer.rb
@@ -1,0 +1,40 @@
+module Api
+  module V1
+    module NationalCircumstance
+      class CategoryCSVSerializer < ApplicationSerializer
+        def initialize(categories)
+          @categories = Array.wrap(categories)
+          @indicators = ::NationalCircumstance::Indicator.all
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        def to_csv
+          year_columns = @categories.flat_map(&:category_years).map(&:year).uniq.sort
+
+          headers = %w(group code indicator category unit location).concat(year_columns)
+
+          CSV.generate do |csv|
+            csv << headers
+
+            @categories.each do |category|
+              indicator = @indicators.select { |i| i.code == category.name }.first
+
+              csv << [
+                category.category_group.name,
+                category.name,
+                indicator&.indicator,
+                indicator&.category,
+                indicator&.unit,
+                category.location.wri_standard_name,
+                year_columns.map do |year|
+                  category.category_years.select { |cy| cy.year == year }.map(&:value)
+                end
+              ].flatten
+            end
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/national_circumstance/category_csv_serializer.rb
+++ b/app/serializers/api/v1/national_circumstance/category_csv_serializer.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     module NationalCircumstance
-      class CategoryCSVSerializer < ApplicationSerializer
+      class CategoryCSVSerializer
         def initialize(categories)
           @categories = Array.wrap(categories)
           @indicators = ::NationalCircumstance::Indicator.all

--- a/app/serializers/api/v1/national_circumstance/priority_csv_serializer.rb
+++ b/app/serializers/api/v1/national_circumstance/priority_csv_serializer.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    module NationalCircumstance
+      class PriorityCSVSerializer < ApplicationSerializer
+        def initialize(priorities)
+          @priorities = Array.wrap(priorities)
+        end
+
+        def to_csv
+          headers = %w(location code value)
+
+          CSV.generate do |csv|
+            csv << headers
+
+            @priorities.each do |priority|
+              csv << [
+                priority.location.wri_standard_name,
+                priority.code,
+                priority.value
+              ]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/national_circumstance/priority_csv_serializer.rb
+++ b/app/serializers/api/v1/national_circumstance/priority_csv_serializer.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     module NationalCircumstance
-      class PriorityCSVSerializer < ApplicationSerializer
+      class PriorityCSVSerializer
         def initialize(priorities)
           @priorities = Array.wrap(priorities)
         end

--- a/config/initializers/renderers.rb
+++ b/config/initializers/renderers.rb
@@ -1,0 +1,15 @@
+ActionController::Renderers.add :zip do |files, options|
+  filename = options[:filename] || controller_name
+
+  zipped_csv = Zip::OutputStream.write_buffer do |zos|
+    files.each do |filename, content|
+      zos.put_next_entry filename
+      zos.print content
+    end
+  end
+  zipped_csv.rewind
+
+  send_data zipped_csv.read,
+            type: Mime[:zip],
+            disposition: "attachment; filename=#{filename}.zip"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   mount Locations::Engine => 'api/v1/locations'
+
   mount HistoricalEmissions::Engine => 'api/v1'
+  get 'api/v1/emissions/download', to: 'historical_emissions/historical_emissions#download'
 
   namespace :api do
     namespace :v1 do

--- a/spec/controllers/api/v1/financial_resource/received_supports_controller_spec.rb
+++ b/spec/controllers/api/v1/financial_resource/received_supports_controller_spec.rb
@@ -26,6 +26,11 @@ describe Api::V1::FinancialResource::ReceivedSupportsController, type: :controll
         parsed_body = JSON.parse(response.body)
         expect(parsed_body['meta'].length).to eq(5)
       end
+
+      it 'responds to zip' do
+        get :index, format: :zip
+        expect(response.content_type).to eq('application/zip')
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/financial_resource/support_needs_controller_spec.rb
+++ b/spec/controllers/api/v1/financial_resource/support_needs_controller_spec.rb
@@ -17,6 +17,11 @@ describe Api::V1::FinancialResource::SupportNeedsController, type: :controller d
         parsed_body = JSON.parse(response.body)
         expect(parsed_body[parsed_body.keys.first].length).to eq(3)
       end
+
+      it 'responds to zip' do
+        get :index, format: :zip
+        expect(response.content_type).to eq('application/zip')
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/ghg/projected_emissions_controller_spec.rb
+++ b/spec/controllers/api/v1/ghg/projected_emissions_controller_spec.rb
@@ -21,11 +21,11 @@ describe Api::V1::Ghg::ProjectedEmissionsController, type: :controller do
         expect(parsed_body[parsed_body.keys.first].length).to eq(3)
       end
 
-      it 'responds to csv' do
-        get :index, format: :csv
-        expect(response.content_type).to eq('text/csv')
+      it 'responds to zip' do
+        get :index, format: :zip
+        expect(response.content_type).to eq('application/zip')
         expect(response.headers['Content-Disposition']).
-          to eq('attachment; filename="projected_emissions.csv"')
+          to eq('attachment; filename=projected_emissions.zip')
       end
 
       it 'lists the metadata' do

--- a/spec/controllers/api/v1/inventory_improvement_projects_controller_spec.rb
+++ b/spec/controllers/api/v1/inventory_improvement_projects_controller_spec.rb
@@ -18,11 +18,9 @@ describe Api::V1::InventoryImprovementProjectsController, type: :controller do
         expect(parsed_body[parsed_body.keys.first].length).to eq(3)
       end
 
-      it 'responds to csv' do
-        get :index, format: :csv
-        expect(response.content_type).to eq('text/csv')
-        expect(response.headers['Content-Disposition']).
-          to eq('attachment; filename="inventory_improvement_projects.csv"')
+      it 'responds to zip' do
+        get :index, format: :zip
+        expect(response.content_type).to eq('application/zip')
       end
     end
   end

--- a/spec/controllers/api/v1/mitigation/mitigation_actions_controller_spec.rb
+++ b/spec/controllers/api/v1/mitigation/mitigation_actions_controller_spec.rb
@@ -17,6 +17,11 @@ describe Api::V1::Mitigation::MitigationActionsController, type: :controller do
         parsed_body = JSON.parse(response.body)
         expect(parsed_body[parsed_body.keys.first].length).to eq(3)
       end
+
+      it 'responds to zip' do
+        get :index, format: :zip
+        expect(response.content_type).to eq('application/zip')
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/mitigation/mitigation_effects_controller_spec.rb
+++ b/spec/controllers/api/v1/mitigation/mitigation_effects_controller_spec.rb
@@ -26,6 +26,11 @@ describe Api::V1::Mitigation::MitigationEffectsController, type: :controller do
         parsed_body = JSON.parse(response.body)
         expect(parsed_body['meta'].length).to eq(5)
       end
+
+      it 'responds to zip' do
+        get :index, format: :zip
+        expect(response.content_type).to eq('application/zip')
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/national_circumstance/categories_controller_spec.rb
+++ b/spec/controllers/api/v1/national_circumstance/categories_controller_spec.rb
@@ -26,6 +26,11 @@ describe Api::V1::NationalCircumstance::CategoriesController, type: :controller 
         parsed_body = JSON.parse(response.body)
         expect(parsed_body['meta'].length).to eq(5)
       end
+
+      it 'responds to zip' do
+        get :index, format: :zip
+        expect(response.content_type).to eq('application/zip')
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/national_circumstance/priorities_controller_spec.rb
+++ b/spec/controllers/api/v1/national_circumstance/priorities_controller_spec.rb
@@ -26,6 +26,11 @@ describe Api::V1::NationalCircumstance::PrioritiesController, type: :controller 
         parsed_body = JSON.parse(response.body)
         expect(parsed_body['meta'].length).to eq(5)
       end
+
+      it 'responds to zip' do
+        get :index, format: :zip
+        expect(response.content_type).to eq('application/zip')
+      end
     end
   end
 end


### PR DESCRIPTION
Changing all of `csv` endpoints into `zip` endpoints to include data source details or even more files. CSV files now have more useful data, however, let's hear what the client says, maybe we still have to add additional data into certain files.