### PR TITLE
Fix/chart colors

### DIFF
--- a/app/javascript/app/components/modal-info/modal-info.js
+++ b/app/javascript/app/components/modal-info/modal-info.js
@@ -1,9 +1,11 @@
 import { connect } from 'react-redux';
 import { withHandlers } from 'recompose';
 import * as actions from './modal-info-actions';
-import reducers, { initialState } from './modal-info-reducers';
+import * as reducers from './modal-info-reducers';
 
 import ModalInfoComponent from './modal-info-component';
+
+const { initialState } = reducers;
 
 const mapStateToProps = ({ modalInfo }) => ({ isOpen: modalInfo.isOpen });
 

--- a/app/javascript/app/components/modal-metadata/modal-metadata.js
+++ b/app/javascript/app/components/modal-metadata/modal-metadata.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { withHandlers } from 'recompose';
 import * as actions from './modal-metadata-actions';
-import reducers, { initialState } from './modal-metadata-reducers';
+import * as reducers from './modal-metadata-reducers';
 
 import ModalMetadataComponent from './modal-metadata-component';
 import {
@@ -9,6 +9,8 @@ import {
   getTabTitles,
   getModalData
 } from './modal-metadata-selectors';
+
+const { initialState } = reducers;
 
 const mapStateToProps = ({ modalMetadata }) => ({
   isOpen: modalMetadata.isOpen,

--- a/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
+++ b/app/javascript/app/pages/ghg-emissions/historical/historical-selectors.js
@@ -213,6 +213,8 @@ const getDataOptions = createSelector(
 
 const getDataSelected = getSectorSelected;
 
+let colorCache = {};
+
 export const getChartConfig = createSelector(
   [ filterChartData, getMetaData, getSectorSelected, getMetricSelected ],
   (data, meta, sectorSelected, metricSelected) => {
@@ -245,8 +247,12 @@ export const getChartConfig = createSelector(
       label: `${subsectorParents[s.label]} - ${s.label}`
     }));
     const theme = {
-      ...getThemeConfig([ ...yColumnOptions, ...yColumnDotsOptions ])
+      ...getThemeConfig(
+        [ ...yColumnOptions, ...yColumnDotsOptions ],
+        colorCache
+      )
     };
+    colorCache = { ...theme, ...colorCache };
     const tooltip = getTooltipConfig([
       ...yColumnOptions,
       ...yColumnDotsOptions

--- a/app/javascript/app/providers/financial-resources-needed-provider/financial-resources-needed-provider.js
+++ b/app/javascript/app/providers/financial-resources-needed-provider/financial-resources-needed-provider.js
@@ -3,9 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './financial-resources-needed-provider-actions';
-import reducers, {
-  initialState
-} from './financial-resources-needed-provider-reducers';
+import * as reducers from './financial-resources-needed-provider-reducers';
+
+const { initialState } = reducers;
 
 class FinancialResourcesNeededProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/financial-resources-received-provider/financial-resources-received-provider.js
+++ b/app/javascript/app/providers/financial-resources-received-provider/financial-resources-received-provider.js
@@ -3,9 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './financial-resources-received-provider-actions';
-import reducers, {
-  initialState
-} from './financial-resources-received-provider-reducers';
+import * as reducers from './financial-resources-received-provider-reducers';
+
+const { initialState } = reducers;
 
 class FinancialResourcesReceivedProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/flagship-programmes-provider/flagship-programmes-provider.js
+++ b/app/javascript/app/providers/flagship-programmes-provider/flagship-programmes-provider.js
@@ -3,9 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './flagship-programmes-provider-actions';
-import reducers, {
-  initialState
-} from './flagship-programmes-provider-reducers';
+import * as reducers from './flagship-programmes-provider-reducers';
+
+const { initialState } = reducers;
 
 class FlagshipProgrammesProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/ghg-emissions-provider/ghg-emissions-provider.js
+++ b/app/javascript/app/providers/ghg-emissions-provider/ghg-emissions-provider.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './ghg-emissions-provider-actions';
-import reducers, { initialState } from './ghg-emissions-provider-reducers';
+import * as reducers from './ghg-emissions-provider-reducers';
+
+const { initialState } = reducers;
 
 class GHGEmissionsProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/ghg-inventory-provider/ghg-inventory-provider.js
+++ b/app/javascript/app/providers/ghg-inventory-provider/ghg-inventory-provider.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './ghg-inventory-provider-actions';
-import reducers, { initialState } from './ghg-inventory-provider-reducers';
+import * as reducers from './ghg-inventory-provider-reducers';
+
+const { initialState } = reducers;
 
 class GHGInventoryProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/metadata-provider/metadata-provider.js
+++ b/app/javascript/app/providers/metadata-provider/metadata-provider.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './metadata-provider-actions';
-import reducers, { initialState } from './metadata-provider-reducers';
+import * as reducers from './metadata-provider-reducers';
+
+const { initialState } = reducers;
 
 class MetaProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/mitigation-actions-provider/mitigation-actions-provider.js
+++ b/app/javascript/app/providers/mitigation-actions-provider/mitigation-actions-provider.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './mitigation-actions-provider-actions';
-import reducers, { initialState } from './mitigation-actions-provider-reducers';
+import * as reducers from './mitigation-actions-provider-reducers';
+
+const { initialState } = reducers;
 
 class MitigationActionsProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/mitigation-effects-provider/mitigation-effects-provider.js
+++ b/app/javascript/app/providers/mitigation-effects-provider/mitigation-effects-provider.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './mitigation-effects-provider-actions';
-import reducers, { initialState } from './mitigation-effects-provider-reducers';
+import * as reducers from './mitigation-effects-provider-reducers';
+
+const { initialState } = reducers;
 
 class MitigationEffectsProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/national-circumstances-priorities-provider/national-circumstances-priorities-provider.js
+++ b/app/javascript/app/providers/national-circumstances-priorities-provider/national-circumstances-priorities-provider.js
@@ -3,10 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './national-circumstances-priorities-provider-actions';
+import * as reducers from './national-circumstances-priorities-provider-reducers';
 
-import reducers, {
-  initialState
-} from './national-circumstances-priorities-provider-reducers';
+const { initialState } = reducers;
 
 class NationalCircumstancesPrioritiesProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/national-circumstances-provider/national-circumstances-provider.js
+++ b/app/javascript/app/providers/national-circumstances-provider/national-circumstances-provider.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 
 import * as actions from './national-circumstances-provider-actions';
 
-import reducers, {
-  initialState
-} from './national-circumstances-provider-reducers';
+import * as reducers from './national-circumstances-provider-reducers';
+
+const { initialState } = reducers;
 
 class NationalCircumstancesProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/natural-disasters-data-provider/natural-disasters-data-provider.js
+++ b/app/javascript/app/providers/natural-disasters-data-provider/natural-disasters-data-provider.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 
 import * as actions from './natural-disasters-data-provider-actions';
 
-import reducers, {
-  initialState
-} from './natural-disasters-data-provider-reducers';
+import * as reducers from './natural-disasters-data-provider-reducers';
+
+const { initialState } = reducers;
 
 class NaturalDisastersDataProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/overview-country-info-provider/overview-country-info-provider.js
+++ b/app/javascript/app/providers/overview-country-info-provider/overview-country-info-provider.js
@@ -3,8 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './overview-country-info-provider-actions';
+import * as reducers from './overview-country-info-reducers';
 
-import reducers, { initialState } from './overview-country-info-reducers';
+const { initialState } = reducers;
 
 const { COUNTRY_ISO } = process.env;
 

--- a/app/javascript/app/providers/projected-emissions-provider/projected-emissions-provider.js
+++ b/app/javascript/app/providers/projected-emissions-provider/projected-emissions-provider.js
@@ -3,9 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './projected-emissions-provider-actions';
-import reducers, {
-  initialState
-} from './projected-emissions-provider-reducers';
+import * as reducers from './projected-emissions-provider-reducers';
+
+const { initialState } = reducers;
 
 class ProjectedEmissionsProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/sections-content-provider/sections-content-provider.js
+++ b/app/javascript/app/providers/sections-content-provider/sections-content-provider.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './sections-content-provider-actions';
-import reducers, { initialState } from './sections-content-provider-reducers';
+import * as reducers from './sections-content-provider-reducers';
+
+const { initialState } = reducers;
 
 class SectionsContentProvider extends PureComponent {
   componentDidMount() {

--- a/app/javascript/app/providers/world-bank-provider/world-bank-provider.js
+++ b/app/javascript/app/providers/world-bank-provider/world-bank-provider.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import * as actions from './world-bank-provider-actions';
-import reducers, { initialState } from './world-bank-provider-reducers';
+import * as reducers from './world-bank-provider-reducers';
+
+const { initialState } = reducers;
 
 const { COUNTRY_ISO } = process.env;
 

--- a/app/javascript/app/utils/graphs.js
+++ b/app/javascript/app/utils/graphs.js
@@ -1,5 +1,7 @@
 import upperFirst from 'lodash/upperFirst';
 import camelCase from 'lodash/camelCase';
+import isEmpty from 'lodash/isEmpty';
+import uniq from 'lodash/uniq';
 import { METRIC_OPTIONS } from 'utils/defaults';
 
 export const DEFAULT_AXES_CONFIG = {
@@ -56,17 +58,36 @@ export const CHART_COLORS = [
   '#E5E6E8'
 ];
 
-export const getThemeConfig = (columns, colors = CHART_COLORS) => {
-  const theme = {};
-  columns.forEach((column, i) => {
-    const index = column.index || i;
-    const correctedIndex = index % colors.length;
-    const icon = column.icon ? { icon: column.icon } : {};
-    theme[column.value] = {
-      stroke: colors[correctedIndex],
-      fill: colors[correctedIndex],
-      ...icon
-    };
-  });
-  return theme;
-};
+export const getThemeConfig = (
+  columns,
+  colorCache = {},
+  colors = CHART_COLORS
+) =>
+  {
+    const theme = {};
+    let newColumns = columns;
+    let usedColors = [];
+    if (colorCache && !isEmpty(colorCache)) {
+      const usedColumns = columns.filter(c => colorCache[c.value]);
+      usedColors = uniq(usedColumns.map(c => colorCache[c.value].stroke));
+      newColumns = columns.filter(c => !usedColumns.includes(c.value));
+    }
+    const themeUsedColors = [];
+    let availableColors = colors.filter(c => !usedColors.includes(c));
+    newColumns.forEach((column, i) => {
+      availableColors = availableColors.filter(
+        c => !themeUsedColors.includes(c)
+      );
+      if (!availableColors.length) availableColors = colors;
+      let index;
+      if (column.index || column.index === 0) {
+        index = { column };
+      } else {
+        index = i % availableColors.length;
+        themeUsedColors.push(selectedColor);
+      }
+      const selectedColor = availableColors[index];
+      theme[column.value] = { stroke: selectedColor, fill: selectedColor };
+    });
+    return { ...theme, ...colorCache };
+  };

--- a/app/javascript/generators/templates/index-connected.js.hbs
+++ b/app/javascript/generators/templates/index-connected.js.hbs
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 // import PropTypes from 'prop-types';
 
 import actions from './{{kebabCase name}}-actions';
-import reducers, { initialState } from './{{kebabCase name}}-reducers';
+import * as reducers from './{{kebabCase name}}-reducers';
 
 import {{properCase name}}Component from './{{kebabCase name}}-component';
 // import { {{camelCase name}}Selector } from './{{kebabCase name}}-selectors';


### PR DESCRIPTION
This PR:
- Fixes a problem with the syntax importing the reducers. It was blocking me for running the app. Let me know if it causes problems for you.
- Creates a color cache as in CW to prevent the colors from changing when we take options in and out of the chart

![nocolorchange](https://user-images.githubusercontent.com/9701591/50491719-002bb980-0a14-11e9-98aa-f450f5fad4ec.gif)
