### PR TITLE
Remove Action and Actor info from mitigation actions tooltip

### DIFF
--- a/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-component.jsx
+++ b/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-component.jsx
@@ -107,7 +107,7 @@ class Summary extends PureComponent {
                         height={400}
                         data={chartData}
                         handleNodeClick={this.handleNodeClick}
-                        tooltipClassName="global_SATMittigationTooltip"
+                        tooltipClassName="global_SATooltip"
                       />
 )
                     : <NoContent minHeight={400} message="No data available" />

--- a/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-selectors.js
+++ b/app/javascript/app/pages/mitigation/mitigation-effects/summary/summary-selectors.js
@@ -189,8 +189,6 @@ const parseChartData = createSelector(
           cautions: metaInfo.cautions,
           unit: metaInfo.unit,
           tooltipContent: [
-            d.name,
-            d.coordinator,
             `${metaInfo.indicator}`,
             value
           ]

--- a/app/javascript/app/styles/global.scss
+++ b/app/javascript/app/styles/global.scss
@@ -18,26 +18,6 @@
     }
   }
 
-  .global_SATMittigationTooltip {
-    @extend .global_SATooltip;
-
-    .multi-line{
-      &:first-child {
-        color: $dark-gray;
-        white-space: nowrap; 
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      &:nth-child(2) {
-        color: $dark-gray;
-        margin-bottom: 8px;
-      }
-      &:nth-last-child(-n+2) {
-        font-weight: bold;
-      }
-    }
-  }
-
   .global_blueTooltip {
     padding: 15px;
     font-size: $font-size-xs;


### PR DESCRIPTION
This PR removes `action` and `actor` info from bubble chart tooltip
[BASECAMP](https://basecamp.com/1756858/projects/13795275/todos/373302896#comment_683401220)
![screenshot from 2019-02-25 16 11 50](https://user-images.githubusercontent.com/15097138/53350972-37392100-3918-11e9-938d-2a4050f44491.png)
